### PR TITLE
Active Active ELB ILB Availability Zones

### DIFF
--- a/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/README.md
+++ b/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/README.md
@@ -1,130 +1,156 @@
-# Availability Zone - Active/Active loadbalanced pair of standalone FortiGates for resilience and scale
+# Active/Active loadbalanced pair of standalone FortiGates for resilience and scale
+
+[![Build Status](https://dev.azure.com/jvh-2520/Fortinet-Azure/_apis/build/status/Active-Active-ELB-ILB?branchName=main)](https://dev.azure.com/jvh-2520/Fortinet-Azure/_build/latest?definitionId=9&branchName=main)
 
 ## Introduction
 
-This design operates almost exactly the same as the more common variant using Availability Sets that can be found [here](../../Active-Active-ELB-ILB/README.md). The main difference between both is that these templates use Availability Zones instead the Availability Sets.
+Enterprises are using Microsoft Azure to extend or replace internal data centers and take advantage of the elasticity of the Public Cloud. While Azure secures the infrastructure, enterprises are responsible for protecting the resources they create. As workloads are being moved from local data centers, connectivity and security are key elements to take into account. FortiGate-VM offers a consistent security posture and protects connectivity across public and private clouds, while high-speed VPN connections protect data.
 
-Microsoft defines an Availability Zone to have the following properties:
-
-- Unique physical location with an Azure Region
-- Each zone is made up of one or more datacenter(s)
-- Independent power, cooling and networking# Availability Zone - Active/Active loadbalanced pair of standalone FortiGates for resilience and scale
-
-## Introduction
-
-This design operates almost exactly the same as the more common variant using Availability Sets that can be found [here](../../Active-Active-ELB-ILB/README.md). The main difference between both is that these templates use Availability Zones instead the Availability Sets.
-
-Microsoft defines an Availability Zone to have the following properties:
-
-- Unique physical location with an Azure Region
-- Each zone is made up of one or more datacenter(s)
-- Independent power, cooling and networking
-- Inter Availability Zone network latency < 2ms (radius of +/- 100km)
-- Fault-tolerant to protect from datacenter failure
-
-Based on information in the presentation ['Inside Azure datacenter architecture with Mark Russinovich' at Microsoft Ignite 2019](https://www.youtube.com/watch?v=X-0V6bYfTpA)
+This Azure ARM template deploys an Active/Active FortiGate pair combined with the Microsoft Azure Standard Load Balancer both in the external and the internal subnet. Additionally, Fortinet Fabric Connectors deliver the ability to create dynamic security policies.
 
 ## Design
 
-VMs running in Microsoft Azure using Availability Zones have a better SLA provided by the platform. Each individual VM in this setup has a 99.99% uptime SLA compared to 99.95% for the VMs running in a Availability Set. SLA documentation from Microsoft can be found [here](https://azure.microsoft.com/en-us/support/legal/sla/virtual-machines/v1_9/).
+In Microsoft Azure, an active/active pair of FortiGate VMs can be deployed that communicate with each other and the Azure fabric. This FortiGate setup will receive the to be inspected traffic using user defined routing (UDR) and public IPs. Send all or specific traffic that needs inspection, going to/coming from on-premises networks or Public Internet by adapting the UDR routing.
 
-A cluster of FortiGate VMs will have a cross region/parallel SLA of 99,999999%. More information about the uptime of the Azure datacenter can be found on [this blog post](https://kvaes.wordpress.com/2020/02/16/is-azure-a-tier-3-datacenter-and-what-about-service-levels-in-a-broader-sense/). FortiGate A will be deployed in Zone 1. FortiGate B will deployed in Zone 2. The template can off course be changed to use other zones.
+This Azure ARM template will automatically deploy a full working environment containing the the following components.
+
+  - 2 FortiGate firewalls in an active/active deployment
+  - 1 external Azure Standard Load Balancer for communication with internet
+  - 1 internal Azure Standard Load Balancer to receive all internal traffic and forwarding towards Azure Gateways connecting ExpressRoute or Azure VPNs.
+  - 1 VNET containing
+    - 1 External subnet
+    - 1 Internal subnet
+    - 2 Protected subnets
+  - 1 public IP for services and FortiGate management
+  - User Defined Routes (UDR) for the protected subnets
 
 ![active/active design](images/fgt-aa.png)
 
-This ARM template can also be used to extend or customized based on your requirements. Additional subnets besides the one's mentioned above are not automatically generated. By adapting the ARM templates you can add additional subnets which preferably require their own routing tables.
+This ARM template can also be used to extend or be customized based on design requirements. Additional subnets besides the ones mentioned above are not automatically generated. By adapting the ARM template additional subnets can be added which prefereably require their own routing tables.
 
 ## How to deploy
 
-The FortiGate solution can be deployed using the Azure Portal or Azure CLI. There are 4 variables needed to complete kickstart the deployment. The deploy.sh script will ask them automatically. When you deploy the ARM template the Azure Portal will request the variables as a requirement.
-
-  - PREFIX : This prefix will be added to each of the resources created by the templates for easy of use, manageability and visibility.
-  - LOCATION : This is the Azure region where the deployment will be deployed
-  - USERNAME : The username used to login to the FortiGate GUI and SSH mangement UI.
-  - PASSWORD : The password used for the FortiGate GUI and SSH management UI.
+The FortiGate solution can be deployed using the Azure Portal or Azure CLI.
 
 ### Azure Portal
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2F40net-cloud%2Ffortinet-azure-solutions%2Fmain%2FFortiGate%2FAvailabilityZones%2FActive-Active-ELB-ILB-AZ%2Fazuredeploy.json" target="_blank">
+Azure Portal:</br>
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmovinalot%2Ffortinet-azure-solutions%2Factive-active-elb-ilb-az%2FFortiGate%2FAvailabilityZones%2FActive-Active-ELB-ILB-AZ%2Fazuredeploy.json" target="_blank">
   <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true"/>
 </a>
-<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2F40net-cloud%2Ffortinet-azure-solutions$2Fmain%2FFortiGate%2FAvailabilityZones%2FActive-Active-ELB-ILB-AZ%2Fazuredeploy.json" target="_blank">
-  <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true"/>
+
+<br/>
+Azure Portal Wizard:</br>
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmovinalot%2Ffortinet-azure-solutions%2Factive-active-elb-ilb-az%2FFortiGate%2FAvailabilityZones%2FActive-Active-ELB-ILB-AZ%2Fazuredeploy.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fmovinalot%2Ffortinet-azure-solutions%2Factive-active-elb-ilb-az%2FFortiGate%2FAvailabilityZones%2FActive-Active-ELB-ILB-AZ%2FcreateUiDefinition.json" target="_blank">
+  <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true"/>
 </a>
 
 ### Azure CLI
 
-To deploy via Azure Cloud Shell you can connect via the Azure Portal or directly to [https://shell.azure.com/](https://shell.azure.com/).
+There are 4 variables needed to complete the deployment, the `deploy.sh` script will ask them automatically. 
 
-- Login into the Azure Cloud Shell
-- Run the following command in the Azure Cloud:
-
-`cd ~/clouddrive/ && wget -qO- https://github.com/40net-cloud/fortinet-azure-solutions/archive/main.tar.gz | tar zxf - && cd ~/clouddrive/fortinet-azure-solutions-main/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/ && ./deploy.sh`
-
-- The script will ask you a few questions to bootstrap a full deployment.
-
-![Azure Cloud Shell](images/azure-cloud-shell.png)
-
-After deployment you will be shown the IP address of all deployed components. You can access both management GUIs and SSH using the public IP address of the load balancer using HTTPS on port 40030, 40031 and for SSH on port 50030 and 50031. The FortiGate VMs are also accessible using their private IPs on the internal subnet using HTTPS on port 443 and SSH on port 22.
-
-## Requirements and limitations
-
-More documentation can be found [here](../../Active-Active-ELB-ILB/README.md).
-
-## License
-[License](LICENSE) © Fortinet Technologies. All rights reserved.
-
-- Inter Availability Zone network latency < 2ms (radius of +/- 100km)
-- Fault-tolerant to protect from datacenter failure
-
-Based on information in the presentation ['Inside Azure datacenter architecture with Mark Russinovich' at Microsoft Ignite 2019](https://www.youtube.com/watch?v=X-0V6bYfTpA)
-
-## Design
-
-VMs running in Microsoft Azure using Availability Zones have a better SLA provided by the platform. Each individual VM in this setup has a 99.99% uptime SLA compared to 99.95% for the VMs running in a Availability Set. SLA documentation from Microsoft can be found [here](https://azure.microsoft.com/en-us/support/legal/sla/virtual-machines/v1_9/).
-
-A cluster of FortiGate VMs will have a cross region/parallel SLA of 99,999999%. More information about the uptime of the Azure datacenter can be found on [this blog post](https://kvaes.wordpress.com/2020/02/16/is-azure-a-tier-3-datacenter-and-what-about-service-levels-in-a-broader-sense/). FortiGate A will be deployed in Zone 1. FortiGate B will deployed in Zone 2. The template can off course be changed to use other zones.
-
-![active/active design](images/fgt-aa.png)
-
-This ARM template can also be used to extend or customized based on your requirements. Additional subnets besides the one's mentioned above are not automatically generated. By adapting the ARM templates you can add additional subnets which preferably require their own routing tables.
-
-## How to deploy
-
-The FortiGate solution can be deployed using the Azure Portal or Azure CLI. There are 4 variables needed to complete kickstart the deployment. The deploy.sh script will ask them automatically. When you deploy the ARM template the Azure Portal will request the variables as a requirement.
-
-  - PREFIX : This prefix will be added to each of the resources created by the templates for easy of use, manageability and visibility.
-  - LOCATION : This is the Azure region where the deployment will be deployed
+  - PREFIX : This prefix will be added to each of the resources created by the templates.
+  - LOCATION : This is the Azure region where the resources will be deployed
   - USERNAME : The username used to login to the FortiGate GUI and SSH mangement UI.
   - PASSWORD : The password used for the FortiGate GUI and SSH management UI.
 
-### Azure Portal
-
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2F40net-cloud%2Ffortinet-azure-solutions%2Fmain%2FFortiGate%2FAvailabilityZones%2FActive-Active-ELB-ILB-AZ%2Fazuredeploy.json" target="_blank">
-  <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true"/>
-</a>
-<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2F40net-cloud%2Ffortinet-azure-solutions$2Fmain%2FFortiGate%2FAvailabilityZones%2FActive-Active-ELB-ILB-AZ%2Fazuredeploy.json" target="_blank">
-  <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true"/>
-</a>
-
-### Azure CLI
-
-To deploy via Azure Cloud Shell you can connect via the Azure Portal or directly to [https://shell.azure.com/](https://shell.azure.com/).
+To deploy via Azure Cloud Shell, connect via the Azure Portal or directly to [https://shell.azure.com/](https://shell.azure.com/).
 
 - Login into the Azure Cloud Shell
 - Run the following command in the Azure Cloud:
 
-`cd ~/clouddrive/ && wget -qO- https://github.com/40net-cloud/fortinet-azure-solutions/archive/main.tar.gz | tar zxf - && cd ~/clouddrive/fortinet-azure-solutions-main/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/ && ./deploy.sh`
+`cd ~/clouddrive/ && wget -qO- https://github.com/movinalot/fortinet-azure-solutions/archive/main.tar.gz | tar zxf - && cd ~/clouddrive/fortinet-azure-solutions/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/ && ./deploy.sh`
 
-- The script will ask you a few questions to bootstrap a full deployment.
+- The script will prompt for a few setting to perform a full deployment.
 
 ![Azure Cloud Shell](images/azure-cloud-shell.png)
 
-After deployment you will be shown the IP address of all deployed components. You can access both management GUIs and SSH using the public IP address of the load balancer using HTTPS on port 40030, 40031 and for SSH on port 50030 and 50031. The FortiGate VMs are also accessible using their private IPs on the internal subnet using HTTPS on port 443 and SSH on port 22.
+After deployment the IP address of all deployed components will be displayed. Access each FortiGate's management GUI or SSH using the public IP address of the load balancer using HTTPS on port 40030, 40031 and for SSH on port 50030 and 50031. THe FortiGate VMs are also acessible using their private IPs on the internal subnet using HTTPS on port 443 and SSH on port 22.
 
 ## Requirements and limitations
 
-More documentation can be found [here](../../Active-Active-ELB-ILB/README.md).
+The ARM template deploys different resources and is required to have the access rights and sufficient quota in the selected Microsoft Azure subscription to deploy the resources.
+
+- By default The template will deploy Standard F2s VMs for this architecture. Other VM instances are supported as well with a minimum of 2 NICs. A list can be found [here](https://docs.fortinet.com/document/fortigate-public-cloud/7.0.0/azure-administration-guide/562841/instance-type-support)
+- Licenses for Fortigate
+  - BYOL: This license type is based on a `.lic` file to be uploaded during or after FortiGate VM deployment.
+    - A demo license can be made available via a Fortinet partner.
+    -  Purchased licenses need to be registered on the [Fortinet support site] (http://support.fortinet.com). Download the `.lic` file after registration. Note, these files can take up to 30 minutes to be active after the initial creation.
+  - Flex-VM: This license type is based on a point system and requires an enablement token to activate
+  - PAYG or OnDemand: This license type is automatically generated during the deployment of the FortiGate and billed as part of the Azure subscription monthly charges.
+- The password provided during deployment must meet password complexity rules from Microsoft Azure:
+  - Must be 12 characters or longer
+  - Must contain characters from at least 3 of the following groups: uppercase characters, lowercase characters, numbers, and special characters excluding '\' or '-'
+- The terms for the FortiGate BYOL/Flex-VM, or PAYG image in the Azure Marketplace need to be accepted before usage. This is done automatically during deployment via the Azure Portal. For the Azure CLI the commands below need to be run before the first deployment in a subscription.
+  - BYOL/Flex-VM:
+`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm`
+  - PAYG:
+`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm_payg_20190624`
+
+## FortiGate configuration
+
+The FortiGate VMs need a specific configuration to match the deployed environment. This configuration can be injected during provisioning or afterwards via the different options including GUI, CLI, FortiManager or REST API.
+
+- [Default configuration using this template](doc/config-provisioning.md)
+
+### Fabric Connector
+The FortiGate-VM uses [Managed Identities](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/) for the SDN Fabric Connector. A SDN Fabric Connector is created automatically during deployment. After deployment, it is required to minimally apply the 'Reader' role to the Azure Subscription you want to resolve Azure Resources from. More information can be found on the [Fortinet Documentation Libary](https://docs.fortinet.com/vm/azure/fortigate/7.0/azure-administration-guide/7.0.0/236610/creating-a-fabric-connector-using-a-managed-identity).
+
+### North South traffic
+When configuring the policies on the FortiGates to allow and forward traffic to internal hosts, it is recommended to enable the NAT checkbox (this will S-NAT the packets to the IP of port2). Doing so will enforce symmetric return.
+
+It is possible to use FGSP to synchronize sessions and thereby allow assymetric return traffic. However, this is not best practice from a security perspective, because it limits the ability of the Intrusion Prevention System (IPS) by potentially only seeing one side of the conversation on each FortiGate. The FortiGate IPS takes both sides of the conversation into account for increased security and visibility. Reducing this visibility on the FortiGate may decrease the IPS efficacy.
+
+Often S-NAT is not desired because it is necessary to retain the original source IP. For HTTP or HTTPS traffic in particular, you can enable the Load Balancing feature on the FortiGate which provides the option to copy the source IP into the X-Forwarded-For header.
+
+To use FGSP for session synchronization, it can be enabled during deployment by uncommenting the section in the customdata.tpl file or adding this recommended configuration to both FortiGate VMs.
+
+```
+config system ha
+    set session-pickup enable
+    set session-pickup-connectionless enable
+    set session-pickup-nat enable
+    set session-pickup-expectation enable
+    set override disable
+end
+
+config system cluster-sync
+    edit 0
+        set peerip 10.0.1.x
+        set syncvd "root"
+    next
+end
+```
+* Where x in 10.0.1.x is the IP of port 1 of the opposite FortiGate. With the default values this would be either 5 or 6.
+
+### Configuration synchronization
+The FortiGate VMs in this Active/Active setup are independent. The FGCP protocol used in the Active/Passive setup to sync the configuration is not applicable in an Active/Active deployment.
+
+To enable configuration sync between both VMs the sync from the autoscaling setup can be used. This will sync all configuration except for configuration items specific to the VM, for example hostname and routing settings. To enable configuration sync the configs below can be applied to each FortiGate.
+
+FortiGate A
+```
+config system auto-scale
+    set status enable
+    set role master
+    set sync-interface "port2"
+    set psksecret "a big secret"
+end
+```
+
+FortiGate B
+```
+config system auto-scale
+    set status enable
+    set sync-interface "port2"
+    set master-ip 172.16.136.69
+    set psksecret "a big secret"
+end
+```
+
+## Support
+Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services.
+For direct issues, please refer to the [Issues](https://github.com/40net-cloud/fortinet-azure-solutions/issues) tab of this GitHub project.
 
 ## License
 [License](LICENSE) © Fortinet Technologies. All rights reserved.

--- a/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/README.md
+++ b/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/README.md
@@ -8,7 +8,72 @@ Microsoft defines an Availability Zone to have the following properties:
 
 - Unique physical location with an Azure Region
 - Each zone is made up of one or more datacenter(s)
+- Independent power, cooling and networking# Availability Zone - Active/Active loadbalanced pair of standalone FortiGates for resilience and scale
+
+## Introduction
+
+This design operates almost exactly the same as the more common variant using Availability Sets that can be found [here](../../Active-Active-ELB-ILB/README.md). The main difference between both is that these templates use Availability Zones instead the Availability Sets.
+
+Microsoft defines an Availability Zone to have the following properties:
+
+- Unique physical location with an Azure Region
+- Each zone is made up of one or more datacenter(s)
 - Independent power, cooling and networking
+- Inter Availability Zone network latency < 2ms (radius of +/- 100km)
+- Fault-tolerant to protect from datacenter failure
+
+Based on information in the presentation ['Inside Azure datacenter architecture with Mark Russinovich' at Microsoft Ignite 2019](https://www.youtube.com/watch?v=X-0V6bYfTpA)
+
+## Design
+
+VMs running in Microsoft Azure using Availability Zones have a better SLA provided by the platform. Each individual VM in this setup has a 99.99% uptime SLA compared to 99.95% for the VMs running in a Availability Set. SLA documentation from Microsoft can be found [here](https://azure.microsoft.com/en-us/support/legal/sla/virtual-machines/v1_9/).
+
+A cluster of FortiGate VMs will have a cross region/parallel SLA of 99,999999%. More information about the uptime of the Azure datacenter can be found on [this blog post](https://kvaes.wordpress.com/2020/02/16/is-azure-a-tier-3-datacenter-and-what-about-service-levels-in-a-broader-sense/). FortiGate A will be deployed in Zone 1. FortiGate B will deployed in Zone 2. The template can off course be changed to use other zones.
+
+![active/active design](images/fgt-aa.png)
+
+This ARM template can also be used to extend or customized based on your requirements. Additional subnets besides the one's mentioned above are not automatically generated. By adapting the ARM templates you can add additional subnets which preferably require their own routing tables.
+
+## How to deploy
+
+The FortiGate solution can be deployed using the Azure Portal or Azure CLI. There are 4 variables needed to complete kickstart the deployment. The deploy.sh script will ask them automatically. When you deploy the ARM template the Azure Portal will request the variables as a requirement.
+
+  - PREFIX : This prefix will be added to each of the resources created by the templates for easy of use, manageability and visibility.
+  - LOCATION : This is the Azure region where the deployment will be deployed
+  - USERNAME : The username used to login to the FortiGate GUI and SSH mangement UI.
+  - PASSWORD : The password used for the FortiGate GUI and SSH management UI.
+
+### Azure Portal
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2F40net-cloud%2Ffortinet-azure-solutions%2Fmain%2FFortiGate%2FAvailabilityZones%2FActive-Active-ELB-ILB-AZ%2Fazuredeploy.json" target="_blank">
+  <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true"/>
+</a>
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2F40net-cloud%2Ffortinet-azure-solutions$2Fmain%2FFortiGate%2FAvailabilityZones%2FActive-Active-ELB-ILB-AZ%2Fazuredeploy.json" target="_blank">
+  <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true"/>
+</a>
+
+### Azure CLI
+
+To deploy via Azure Cloud Shell you can connect via the Azure Portal or directly to [https://shell.azure.com/](https://shell.azure.com/).
+
+- Login into the Azure Cloud Shell
+- Run the following command in the Azure Cloud:
+
+`cd ~/clouddrive/ && wget -qO- https://github.com/40net-cloud/fortinet-azure-solutions/archive/main.tar.gz | tar zxf - && cd ~/clouddrive/fortinet-azure-solutions-main/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/ && ./deploy.sh`
+
+- The script will ask you a few questions to bootstrap a full deployment.
+
+![Azure Cloud Shell](images/azure-cloud-shell.png)
+
+After deployment you will be shown the IP address of all deployed components. You can access both management GUIs and SSH using the public IP address of the load balancer using HTTPS on port 40030, 40031 and for SSH on port 50030 and 50031. The FortiGate VMs are also accessible using their private IPs on the internal subnet using HTTPS on port 443 and SSH on port 22.
+
+## Requirements and limitations
+
+More documentation can be found [here](../../Active-Active-ELB-ILB/README.md).
+
+## License
+[License](LICENSE) © Fortinet Technologies. All rights reserved.
+
 - Inter Availability Zone network latency < 2ms (radius of +/- 100km)
 - Fault-tolerant to protect from datacenter failure
 

--- a/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/azure-pipelines.yml
+++ b/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/azure-pipelines.yml
@@ -19,7 +19,7 @@ steps:
   displayName: 'Publish ARM TTK results'
   inputs:
     testRunner: NUnit
-    testResultsFiles: '**\*-armttk.xml'
+    testResultsFiles: '**/*-armttk.xml'
     testRunTitle: 'ARM TTK verification'
   condition: always()
 
@@ -27,7 +27,7 @@ steps:
   displayName: 'Publish Test Results **\TEST-*.xml'
   inputs:
     testRunner: NUnit
-    testResultsFiles: '**\TEST-*.xml'
+    testResultsFiles: '**/TEST-*.xml'
     testRunTitle: 'ARM template and deployment test'
 
 trigger:

--- a/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/azuredeploy.json
+++ b/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/azuredeploy.json
@@ -5,22 +5,22 @@
     "adminUsername": {
       "type": "string",
       "metadata": {
-        "description": "Username for the fortigate VM"
+        "description": "Username for the FortiGate VM"
       }
     },
     "adminPassword": {
       "type": "securestring",
       "metadata": {
-        "description": "Password for the fortigate VM"
+        "description": "Password for the FortiGate VM"
       }
     },
-    "fortigateNamePrefix": {
+    "fortiGateNamePrefix": {
       "type": "string",
       "metadata": {
-        "description": "Name for fortigate virtual appliances (A & B will be appended to the end of each respectively)."
+        "description": "Naming prefix for all deployed resources. The FortiGate VMs will have the suffix '-FGT-A' and '-FGT-B'. For example if the prefix is 'ACME-01' the FortiGates will be named 'ACME-01-FGT-A' and 'ACME-01-FGT-B'"
       }
     },
-    "fortigateImageSKU": {
+    "fortiGateImageSKU": {
       "type": "string",
       "defaultValue": "fortinet_fg-vm",
       "allowedValues": [
@@ -31,7 +31,7 @@
         "description": "Identifies whether to to use PAYG (on demand licensing) or BYOL license model (where license is purchased separately)"
       }
     },
-    "fortigateImageVersion": {
+    "fortiGateImageVersion": {
       "type": "string",
       "defaultValue": "latest",
       "allowedValues": [
@@ -43,43 +43,71 @@
         "6.4.2",
         "6.4.3",
         "6.4.5",
+        "7.0.0",
         "latest"
       ],
       "metadata": {
         "description": "Select the image version"
       }
     },
+    "fortiGateAditionalCustomData": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The ARM template provides a basic configuration. Additional configuration can be added here."
+      }
+    },
     "instanceType": {
       "type": "string",
       "defaultValue": "Standard_F2s",
-      "allowedValues": [ "Standard_F1s", "Standard_F2s", "Standard_F4s", "Standard_F8s", "Standard_F16s", "Standard_F1", "Standard_F2", "Standard_F4", "Standard_F8", "Standard_F16", "Standard_F2s_v2", "Standard_F4s_v2", "Standard_F8s_v2", "Standard_F16s_v2", "Standard_F32s_v2", "Standard_DS1_v2", "Standard_DS2_v2", "Standard_DS3_v2", "Standard_DS4_v2", "Standard_DS5_v2", "Standard_D2s_v3", "Standard_D4s_v3", "Standard_D8s_v3", "Standard_D16s_v3", "Standard_D32s_v3"],
+      "allowedValues": [ "Standard_F1", "Standard_F2", "Standard_F4", "Standard_F8", "Standard_F16", "Standard_F1s", "Standard_F2s", "Standard_F4s", "Standard_F8s", "Standard_F16s", "Standard_F2s_v2", "Standard_F4s_v2", "Standard_F8s_v2", "Standard_F16s_v2", "Standard_F32s_v2", "Standard_D1_v2", "Standard_D2_v2", "Standard_D3_v2", "Standard_D4_v2", "Standard_D5_v2", "Standard_DS1_v2", "Standard_DS2_v2", "Standard_DS3_v2", "Standard_DS4_v2", "Standard_DS5_v2", "Standard_D2_v3", "Standard_D4_v3", "Standard_D8_v3", "Standard_D16_v3", "Standard_D32_v3", "Standard_D2s_v3", "Standard_D4s_v3", "Standard_D8s_v3", "Standard_D16s_v3", "Standard_D32s_v3"],
       "metadata": {
         "description": "Virtual Machine size selection"
       }
     },
-    "publicIPNewOrExisting": {
+    "availabilityOptions": {
+      "type": "string",
+      "allowedValues": [
+        "Availability Set",
+        "Availability Zones"
+      ],
+      "defaultValue": "Availability Set",
+      "metadata": {
+        "description": "Deploy FortiGate VMs in an Availability Set or Availability Zones. If Availability Zones deployment is selected but the location does not support Availability Zones an Availability Set will be deployed. If Availability Zones deployment is selected and Availability Zones are available in the location, FortiGate A will be placed in Zone 1, FortiGate B will be placed in Zone 2"
+      }
+    },
+    "acceleratedNetworking": {
+      "type": "string",
+      "defaultValue": "true",
+      "allowedValues": [ "false", "true" ],
+      "metadata": {
+        "description": "Accelerated Networking enables direct connection between the VM and network card. Only available on 2 CPU F/Fs and 4 CPU D/Dsv2, D/Dsv3, E/Esv3, Fsv2, Lsv2, Ms/Mms and Ms/Mmsv2"
+      }
+    },
+    "publicIP1NewOrExisting": {
       "type": "string",
       "defaultValue": "new",
       "allowedValues": [
         "new",
-        "existing"
+        "existing",
+        "none"
       ],
       "metadata": {
-        "description": "Identify if to use a public IP, and if so whether it's new"
+        "description": "Use a public IP, is it new or existing"
       }
     },
-    "publicIPName": {
-      "type": "string",
-      "defaultValue": "FGTLBPublicIP",
-      "metadata": {
-        "description": "Name of Public IP address 1"
-      }
-    },
-    "publicIPResourceGroup": {
+    "publicIP1Name": {
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "Resource group to which the Public IP belongs."
+        "description": "Name of Public IP address, if no name is provided the default name will be the Resource Group Name as the Prefix and '-FGT-PIP' as the suffix"
+      }
+    },
+    "publicIP1ResourceGroup": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Public IP Resource Group, this value is required if an existing Public IP is selected"
       }
     },
     "vnetNewOrExisting": {
@@ -97,14 +125,14 @@
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "Name of the Azure virtual network."
+        "description": "Name of the Azure virtual network, required if utilizing and existing VNET. If no name is provided the default name will be the Resource Group Name as the Prefix and '-VNET' as the suffix"
       }
     },
     "vnetResourceGroup": {
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "Resource Group containing the virtual network - or new resource group from above (if new vnet)"
+        "description": "Resource Group containing the existing virtual network, leave blank if a new VNET is being utilized"
       }
     },
     "vnetAddressPrefix": {
@@ -116,7 +144,7 @@
     },
     "subnet1Name": {
       "type": "string",
-      "defaultValue": "ExteralSubnet",
+      "defaultValue": "ExternalSubnet",
       "metadata": {
         "description": "Subnet 1 Name"
       }
@@ -126,6 +154,13 @@
       "defaultValue": "172.16.136.0/26",
       "metadata": {
         "description": "Subnet 1 Prefix"
+      }
+    },
+    "subnet1StartAddress": {
+      "type": "string",
+      "defaultValue": "172.16.136.4",
+      "metadata": {
+        "description": "Subnet 1 start address, 2 consecutive private IPs are required"
       }
     },
     "subnet2Name": {
@@ -142,9 +177,16 @@
         "description": "Subnet 2 Prefix"
       }
     },
+    "subnet2StartAddress": {
+      "type": "string",
+      "defaultValue": "172.16.136.68",
+      "metadata": {
+        "description": "Subnet 2 start address, 2 consecutive private IPs are required"
+      }
+    },
     "subnet3Name": {
       "type": "string",
-      "defaultValue": "ProtectedSubnet",
+      "defaultValue": "ProtectedASubnet",
       "metadata": {
         "description": "Subnet 3 Name"
       }
@@ -154,6 +196,73 @@
       "defaultValue": "172.16.137.0/24",
       "metadata": {
         "description": "Subnet 3 Prefix"
+      }
+    },
+    "subnet4Name": {
+      "type": "string",
+      "defaultValue": "ProtectedBSubnet",
+      "metadata": {
+        "description": "Subnet 4 Name"
+      }
+    },
+    "subnet4Prefix": {
+      "type": "string",
+      "defaultValue": "172.16.138.0/24",
+      "metadata": {
+        "description": "Subnet 4 Prefix"
+      }
+    },
+    "fortiManager": {
+      "type": "string",
+      "defaultValue": "no",
+      "allowedValues": [
+        "yes",
+        "no"
+      ],
+      "metadata": {
+        "description": "Connect to FortiManager"
+      }
+    },
+    "fortiManagerIP": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "FortiManager IP or DNS name to connect to on port TCP/541"
+      }
+    },
+    "fortiManagerSerial": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "FortiManager serial number to add the deployed FortiGate into the FortiManager"
+      }
+    },
+    "fortiGateLicenseBYOLA": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Primary FortiGate BYOL license content"
+      }
+    },
+    "fortiGateLicenseBYOLB": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Secondary FortiGate BYOL license content"
+      }
+    },
+    "fortiGateLicenseFlexVMA": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Primary FortiGate BYOL Flex-VM license token"
+      }
+    },
+    "fortiGateLicenseFlexVMB": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Secondary FortiGate BYOL Flex-VM license token"
       }
     },
     "location": {
@@ -167,38 +276,57 @@
       "type": "object",
       "defaultValue": {
         "publisher": "Fortinet",
-        "template": "Active-Active-ELB-ILB-AZ",
-        "provider": "6EB3B02F-50E5-4A3E-8CB8-2E129258AAAZ"
+        "template": "Active-Active-ELB-ILB-AZORAS",
+        "provider": "6EB3B02F-50E5-4A3E-8CB8-2E129258AAAZORAS"
       }
     }
   },
   "variables": {
+    "location": "[parameters('location')]",
     "imagePublisher": "fortinet",
     "imageOffer": "fortinet_fortigate-vm_v5",
 
-    "vnetName": "[if(equals(parameters('vnetName'),''),concat(parameters('fortigateNamePrefix'),'-VNET'),parameters('vnetName'))]",
+    "availabilitySetName": "[concat(parameters('fortiGateNamePrefix'),'-AvailabilitySet')]",
+    "availabilitySetId": {
+      "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
+    },
+
+    "vnetName": "[if(equals(parameters('vnetName'),''),concat(parameters('fortiGateNamePrefix'),'-VNET'),parameters('vnetName'))]",
     "subnet1Id": "[if(equals(parameters('vnetNewOrExisting'),'new'),resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'),parameters('subnet1Name')),resourceId(parameters('vnetResourceGroup'),'Microsoft.Network/virtualNetworks/subnets', variables('vnetName'),parameters('subnet1Name')))]",
     "subnet2Id": "[if(equals(parameters('vnetNewOrExisting'),'new'),resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'),parameters('subnet2Name')),resourceId(parameters('vnetResourceGroup'),'Microsoft.Network/virtualNetworks/subnets', variables('vnetName'),parameters('subnet2Name')))]",
 
-    "fgaVmName": "[concat(parameters('fortigateNamePrefix'),'-FGT-A')]",
-    "fgbVmName": "[concat(parameters('fortigateNamePrefix'),'-FGT-B')]",
+    "fgaVmName": "[concat(parameters('fortiGateNamePrefix'),'-FGT-A')]",
+    "fgbVmName": "[concat(parameters('fortiGateNamePrefix'),'-FGT-B')]",
+    "fmgCustomData": "[if(equals(parameters('fortiManager'),'yes'),concat('\nconfig system central-management\nset type fortimanager\n set fmg ',parameters('fortiManagerIP'),'\nset serial-number ', parameters('fortiManagerSerial'), '\nend\n config system interface\n edit port1\n append allowaccess fgfm\n end\n config system interface\n edit port2\n append allowaccess fgfm\n end\n'),'')]",
+    "fgaCustomDataFlexVM": "[if(equals(parameters('fortiGateLicenseFlexVMA'),''),'',concat('exec vm-license ',parameters('fortiGateLicenseFlexVMA'), '\n'))]",
+    "fgBCustomDataFlexVM": "[if(equals(parameters('fortiGateLicenseFlexVMB'),''),'',concat('exec vm-license ',parameters('fortiGateLicenseFlexVMB'), '\n'))]",
+    "customDataHeader": "Content-Type: multipart/mixed; boundary=\"12345\"\nMIME-Version: 1.0\n--12345\nContent-Type: text/plain; charset=\"us-ascii\"\nMIME-Version: 1.0\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment; filename=\"config\"\n\n",
+    "fgaCustomDataBody": "[concat('config system sdn-connector\nedit AzureSDN\nset type azure\nnext\nend\nconfig router static\n edit 1\n set gateway ', variables('sn1GatewayIP'), '\n set device port1\n next\n edit 2\n set dst ', parameters('vnetAddressPrefix'), '\n set gateway ', variables('sn2GatewayIP'), '\n set device port2\n next\n edit 3\nset dst 168.63.129.16 255.255.255.255\nset device port2\n set gateway ', variables ('sn2GatewayIP'), '\n next\nedit 4\nset dst 168.63.129.16 255.255.255.255\nset device port1\n set gateway ', variables ('sn1GatewayIP'), '\n next\n end\n config system probe-response\n set mode http-probe\n end\n config system interface\n edit port1\n set mode static\n set ip ', variables('sn1IPfga'), '/', variables('sn1CIDRmask'), '\n set description external\n set allowaccess ping ssh https probe-response\n next\n edit port2\n set mode static\n set ip ', variables('sn2IPfga'), '/', variables('sn2CIDRmask'), '\n set description internal\n set allowaccess ping ssh https probe-response\n next\n end\n', variables('fmgCustomData'), parameters('fortiGateAditionalCustomData'), '\n', variables('fgaCustomDataFlexVM'), '\n')]",
+    "fgbCustomDataBody": "[concat('config system sdn-connector\nedit AzureSDN\nset type azure\nnext\nend\nconfig router static\n edit 1\n set gateway ', variables('sn1GatewayIP'), '\n set device port1\n next\n edit 2\n set dst ', parameters('vnetAddressPrefix'), '\n set gateway ', variables('sn2GatewayIP'), '\n set device port2\n next\n edit 3\nset dst 168.63.129.16 255.255.255.255\nset device port2\n set gateway ', variables ('sn2GatewayIP'), '\n next\nedit 4\nset dst 168.63.129.16 255.255.255.255\nset device port1\n set gateway ', variables ('sn1GatewayIP'), '\n next\n end\n config system probe-response\n set mode http-probe\n end\n config system interface\n edit port1\n set mode static\n set ip ', variables('sn1IPfgb'), '/', variables('sn1CIDRmask'), '\n set description external\n set allowaccess ping ssh https probe-response\n next\n edit port2\n set mode static\n set ip ', variables('sn2IPfgb'), '/', variables('sn2CIDRmask'), '\n set description internal\n set allowaccess ping ssh https probe-response\n next\n end\n', variables('fmgCustomData'), parameters('fortiGateAditionalCustomData'), '\n', variables('fgbCustomDataFlexVM'), '\n')]",
+    "customDataLicenseHeader": "--12345\nContent-Type: text/plain; charset=\"us-ascii\"\nMIME-Version: 1.0\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment; filename=\"fgtlicense\"\n\n",
+    "customDataFooter": "--12345--\n",
+    "fgaCustomDataCombined": "[concat(variables('customDataHeader'),variables('fgaCustomDataBody'),variables('customDataLicenseHeader'), parameters('fortiGateLicenseBYOLA'), variables('customDataFooter'))]",
+    "fgbCustomDataCombined": "[concat(variables('customDataHeader'),variables('fgbCustomDataBody'),variables('customDataLicenseHeader'), parameters('fortiGateLicenseBYOLB'), variables('customDataFooter'))]",
+    "fgaCustomData": "[base64(if(equals(parameters('fortiGateLicenseBYOLA'),''),variables('fgaCustomDataBody'),variables('fgaCustomDataCombined')))]",
+    "fgbCustomData": "[base64(if(equals(parameters('fortiGateLicenseBYOLB'),''),variables('fgbCustomDataBody'),variables('fgbCustomDataCombined')))]",
 
-    "routeTable3Name": "[concat(parameters('fortigateNamePrefix'),'-',parameters('subnet3Name'),'-','RouteTable')]",
+    "routeTable3Name": "[concat(parameters('fortiGateNamePrefix'),'-',parameters('subnet3Name'),'-','RouteTable')]",
     "routeTable3Id": "[resourceId('Microsoft.Network/routeTables',variables('routeTable3Name'))]",
-
-    "fgaNic1Name": "[concat(variables('fgaVmName'),'-Nic0')]",
+    "routeTable4Name": "[concat(parameters('fortiGateNamePrefix'),'-',parameters('subnet4Name'),'-','routetable')]",
+    "routeTable4Id": "[resourceId('Microsoft.Network/routeTables',variables('routeTable4Name'))]",
+    "fgaNic1Name": "[concat(variables('fgaVmName'),'-Nic1')]",
     "fgaNic1Id": "[resourceId('Microsoft.Network/networkInterfaces',variables('fgaNic1Name'))]",
-    "fgaNic2Name": "[concat(variables('fgaVmName'),'-Nic1')]",
+    "fgaNic2Name": "[concat(variables('fgaVmName'),'-Nic2')]",
     "fgaNic2Id": "[resourceId('Microsoft.Network/networkInterfaces',variables('fgaNic2Name'))]",
-    "fgbNic1Name": "[concat(variables('fgbVmName'),'-Nic0')]",
+    "fgbNic1Name": "[concat(variables('fgbVmName'),'-Nic1')]",
     "fgbNic1Id": "[resourceId('Microsoft.Network/networkInterfaces',variables('fgbNic1Name'))]",
-    "fgbNic2Name": "[concat(variables('fgbVmName'),'-Nic1')]",
+    "fgbNic2Name": "[concat(variables('fgbVmName'),'-Nic2')]",
     "fgbNic2Id": "[resourceId('Microsoft.Network/networkInterfaces',variables('fgbNic2Name'))]",
 
-    "publicIPName": "[if(equals(parameters('publicIPName'),''),concat(parameters('fortigateNamePrefix'),'-FGT-PIP'),parameters('publicIPName'))]",
-    "publicIPId": "[if(equals(parameters('publicIPNewOrExisting'),'new'),resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPName')),resourceId(parameters('publicIPResourceGroup'),'Microsoft.Network/publicIPAddresses',variables('publicIPName')))]",
+    "publicIP1Name": "[if(equals(parameters('publicIP1Name'),''),concat(parameters('fortiGateNamePrefix'),'-FGT-PIP'),parameters('publicIP1Name'))]",
+    "publicIP1Id": "[if(equals(parameters('publicIP1NewOrExisting'),'new'),resourceId('Microsoft.Network/publicIPAddresses',variables('publicIP1Name')),resourceId(parameters('publicIP1ResourceGroup'),'Microsoft.Network/publicIPAddresses',variables('publicIP1Name')))]",
 
-    "nsgName": "[concat(parameters('fortigateNamePrefix'),'-NSG-Allow-All')]",
+    "nsgName": "[concat(parameters('fortiGateNamePrefix'),'-NSG-Allow-All')]",
     "nsgId": "[resourceId('Microsoft.Network/networkSecurityGroups/',variables('nsgName'))]",
 
     "sn1IPArray": "[split(parameters('subnet1Prefix'),'.')]",
@@ -210,8 +338,9 @@
     "sn1IPArray1": "[string(int(variables('sn1IPArray')[1]))]",
     "sn1IPArray0": "[string(int(variables('sn1IPArray')[0]))]",
     "sn1GatewayIP": "[concat(variables('sn1IPArray0'),'.',variables('sn1IPArray1'),'.',variables('sn1IPArray2'),'.',variables('sn1IPArray3'))]",
-    "sn1IPfga": "[concat(variables('sn1IPArray0'),'.',variables('sn1IPArray1'),'.',variables('sn1IPArray2'),'.',add(int(variables('sn1IPArray2nd')[0]),5))]",
-    "sn1IPfgb": "[concat(variables('sn1IPArray0'),'.',variables('sn1IPArray1'),'.',variables('sn1IPArray2'),'.',add(int(variables('sn1IPArray2nd')[0]),6))]",
+    "sn1IPStartAddress": "[split(parameters('subnet1StartAddress'),'.')]",
+    "sn1IPfga": "[concat(variables('sn1IPArray0'),'.',variables('sn1IPArray1'),'.',variables('sn1IPArray2'),'.',int(variables('sn1IPStartAddress')[3]))]",
+    "sn1IPfgb": "[concat(variables('sn1IPArray0'),'.',variables('sn1IPArray1'),'.',variables('sn1IPArray2'),'.',add(int(variables('sn1IPStartAddress')[3]),1))]",
 
     "sn2IPArray": "[split(parameters('subnet2Prefix'),'.')]",
     "sn2IPArray2ndString": "[string(variables('sn2IPArray')[3])]",
@@ -222,18 +351,19 @@
     "sn2IPArray1": "[string(int(variables('sn2IPArray')[1]))]",
     "sn2IPArray0": "[string(int(variables('sn2IPArray')[0]))]",
     "sn2GatewayIP": "[concat(variables('sn2IPArray0'),'.',variables('sn2IPArray1'),'.',variables('sn2IPArray2'),'.',variables('sn2IPArray3'))]",
-    "sn2IPlb": "[concat(variables('sn2IPArray0'),'.',variables('sn2IPArray1'),'.',variables('sn2IPArray2'),'.',add(int(variables('sn2IPArray2nd')[0]),4))]",
-    "sn2IPfga": "[concat(variables('sn2IPArray0'),'.',variables('sn2IPArray1'),'.',variables('sn2IPArray2'),'.',add(int(variables('sn2IPArray2nd')[0]),5))]",
-    "sn2IPfgb": "[concat(variables('sn2IPArray0'),'.',variables('sn2IPArray1'),'.',variables('sn2IPArray2'),'.',add(int(variables('sn2IPArray2nd')[0]),6))]",
+    "sn2IPStartAddress": "[split(parameters('subnet2StartAddress'),'.')]",
+    "sn2IPlb": "[concat(variables('sn2IPArray0'),'.',variables('sn2IPArray1'),'.',variables('sn2IPArray2'),'.',int(variables('sn2IPStartAddress')[3]))]",
+    "sn2IPfga": "[concat(variables('sn2IPArray0'),'.',variables('sn2IPArray1'),'.',variables('sn2IPArray2'),'.',add(int(variables('sn2IPStartAddress')[3]),1))]",
+    "sn2IPfgb": "[concat(variables('sn2IPArray0'),'.',variables('sn2IPArray1'),'.',variables('sn2IPArray2'),'.',add(int(variables('sn2IPStartAddress')[3]),2))]",
 
-    "internalLBName": "[concat(parameters('fortigateNamePrefix'),'-InternalLoadBalancer')]",
+    "internalLBName": "[concat(parameters('fortiGateNamePrefix'),'-InternalLoadBalancer')]",
     "internalLBId": "[resourceId('Microsoft.Network/loadBalancers',variables('internalLBName'))]",
-    "internalLBFEName": "[concat(parameters('fortigateNamePrefix'),'-ILB-',parameters('subnet2Name'),'-FrontEnd')]",
-    "internalLBFEId": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations/',variables('internalLBName'),variables('internalLBFEName'))]",
-    "internalLBBEName": "[concat(parameters('fortigateNamePrefix'),'-ILB-',parameters('subnet2Name'),'-BackEnd')]",
-    "internalLBBEId": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools/',variables('internalLBName'),variables('internalLBBEName'))]",
+    "internalLBFEName": "[concat(parameters('fortiGateNamePrefix'),'-ILB-',parameters('subnet2Name'),'-FrontEnd')]",
+    "internalLBFEId": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations',variables('internalLBName'),variables('internalLBFEName'))]",
+    "internalLBBEName": "[concat(parameters('fortiGateNamePrefix'),'-ILB-',parameters('subnet2Name'),'-BackEnd')]",
+    "internalLBBEId": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools',variables('internalLBName'),variables('internalLBBEName'))]",
     "internalLBProbeName": "lbprobe",
-    "internalLBProbeId": "[resourceId('Microsoft.Network/loadBalancers/probes/',variables('internalLBName'),variables('internalLBProbeName'))]",
+    "internalLBProbeId": "[resourceId('Microsoft.Network/loadBalancers/probes',variables('internalLBName'),variables('internalLBProbeName'))]",
 
     "externalLBName_NatRule_FGAdminPerm_fga": "[concat(variables('fgaVmName'),'FGAdminPerm')]",
     "externalLBId_NatRule_FGAdminPerm_fga": "[resourceId('Microsoft.Network/loadBalancers/inboundNatRules',variables('externalLBName'),variables('externalLBName_NatRule_FGAdminPerm_fga'))]",
@@ -243,27 +373,48 @@
     "externalLBId_NatRule_FGAdminPerm_fgb": "[resourceId('Microsoft.Network/loadBalancers/inboundNatRules',variables('externalLBName'),variables('externalLBName_NatRule_FGAdminPerm_fgb'))]",
     "externalLBName_NatRule_SSH_fgb": "[concat(variables('fgbVmName'),'SSH')]",
     "externalLBId_NatRule_SSH_fgb": "[resourceId('Microsoft.Network/loadBalancers/inboundNatRules',variables('externalLBName'),variables('externalLBName_NatRule_SSH_fgb'))]",
-    "externalLBName": "[concat(parameters('fortigateNamePrefix'),'-ExternalLoadBalancer')]",
+    "externalLBName": "[concat(parameters('fortiGateNamePrefix'),'-ExternalLoadBalancer')]",
     "externalLBId": "[resourceId('Microsoft.Network/loadBalancers',variables('externalLBName'))]",
-    "externalLBFEName": "[concat(parameters('fortigateNamePrefix'),'-ELB-',parameters('subnet1Name'),'-FrontEnd')]",
-    "externalLBFEId": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations/',variables('externalLBName'),variables('externalLBFEName'))]",
-    "externalLBBEName": "[concat(parameters('fortigateNamePrefix'),'-ELB-',parameters('subnet1Name'),'-BackEnd')]",
-    "externalLBBEId": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools/',variables('externalLBName'),variables('externalLBBEName'))]",
+    "externalLBFEName": "[concat(parameters('fortiGateNamePrefix'),'-ELB-',parameters('subnet1Name'),'-FrontEnd')]",
+    "externalLBFEId": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations',variables('externalLBName'),variables('externalLBFEName'))]",
+    "externalLBBEName": "[concat(parameters('fortiGateNamePrefix'),'-ELB-',parameters('subnet1Name'),'-BackEnd')]",
+    "externalLBBEId": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools',variables('externalLBName'),variables('externalLBBEName'))]",
     "externalLBProbeName": "lbprobe",
-    "externalLBProbeId": "[resourceId('Microsoft.Network/loadBalancers/probes/',variables('externalLBName'),variables('externalLBProbeName'))]"
+    "externalLBProbeId": "[resourceId('Microsoft.Network/loadBalancers/probes',variables('externalLBName'),variables('externalLBProbeName'))]",
+
+    "useAZ": "[and(not(empty(pickZones('Microsoft.Compute', 'virtualMachines', variables('location')))), equals(parameters('availabilityOptions'), 'Availability Zones'))]",
+    "zone1": ["1"],
+    "zone2": ["2"]
   },
   "resources": [
     {
       "apiVersion": "2020-10-01",
-      "name": "pid-09ed3dc3-4cf7-5410-b01c-c9bdfc039530",
+      "name": "[concat(parameters('fortiGateNamePrefix'), '-fortinetdeployment-', uniquestring(resourceGroup().id))]",
       "type": "Microsoft.Resources/deployments",
       "properties":{
-       "mode": "Incremental",
-       "template": {
-         "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deplymentTemplate.json#",
-         "contentVersion": "1.0.0.0",
-         "resources": []
-       }
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deplymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": []
+        }
+      }
+    },
+    {
+      "apiVersion": "2019-07-01",
+      "type": "Microsoft.Compute/availabilitySets",
+      "condition": "[not(variables('useAZ'))]",
+      "name": "[variables('availabilitySetName')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "provider": "[toUpper(parameters('fortinetTags').provider)]"
+      },
+      "properties": {
+        "platformFaultDomainCount": 2,
+        "platformUpdateDomainCount": 2
+      },
+      "sku": {
+        "name":  "Aligned"
       }
     },
     {
@@ -273,7 +424,8 @@
       "name": "[variables('vnetName')]",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[variables('routeTable3Id')]"
+        "[variables('routeTable3Id')]",
+        "[variables('routeTable4Id')]"
       ],
       "properties": {
         "addressSpace": {
@@ -302,6 +454,15 @@
                 "id": "[variables('routeTable3Id')]"
               }
             }
+          },
+          {
+            "name": "[parameters('subnet4Name')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnet4Prefix')]",
+              "routeTable": {
+                "id": "[variables('routeTable4Id')]"
+              }
+            }
           }
         ]
       }
@@ -312,7 +473,7 @@
       "name": "[variables('internalLBName')]",
       "location": "[parameters('location')]",
       "tags": {
-       "provider": "[toUpper(parameters('fortinetTags').provider)]"
+        "provider": "[toUpper(parameters('fortinetTags').provider)]"
       },
       "sku": {
         "name": "Standard"
@@ -378,7 +539,7 @@
       "name": "[variables('routeTable3Name')]",
       "location": "[parameters('location')]",
       "tags": {
-       "provider": "[toUpper(parameters('fortinetTags').provider)]"
+        "provider": "[toUpper(parameters('fortinetTags').provider)]"
       },
       "properties": {
         "routes": [
@@ -395,8 +556,29 @@
     },
     {
       "apiVersion": "2020-04-01",
-      "name": "[variables('nsgName')]",
+      "type": "Microsoft.Network/routeTables",
+      "name": "[variables('routeTable4Name')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "provider": "[toUpper(parameters('fortinetTags').provider)]"
+      },
+      "properties": {
+        "routes": [
+          {
+            "name": "toDefault",
+            "properties": {
+              "addressPrefix": "0.0.0.0/0",
+              "nextHopType": "VirtualAppliance",
+              "nextHopIPAddress": "[variables('sn2IPlb')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2020-04-01",
       "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('nsgName')]",
       "location": "[parameters('location')]",
       "tags": {
         "provider": "[toUpper(parameters('fortinetTags').provider)]"
@@ -435,10 +617,10 @@
       }
     },
     {
-      "condition": "[equals(parameters('publicIPNewOrExisting'), 'new')]",
+      "condition": "[equals(parameters('publicIP1NewOrExisting'), 'new')]",
       "apiVersion": "2020-04-01",
       "type": "Microsoft.Network/publicIPAddresses",
-      "name": "[variables('publicIPName')]",
+      "name": "[variables('publicIP1Name')]",
       "location": "[parameters('location')]",
       "tags": {
         "provider": "[toUpper(parameters('fortinetTags').provider)]"
@@ -447,7 +629,7 @@
         "name": "Standard"
       },
       "properties": {
-        "publicIPAllocationMethod": "Static"
+        "publicIPAllocationMethod": "static"
       }
     },
     {
@@ -463,7 +645,7 @@
         "name": "Standard"
       },
       "dependsOn": [
-        "[variables('publicIPId')]"
+        "[variables('publicIP1Name')]"
       ],
       "properties": {
         "frontendIPConfigurations": [
@@ -471,7 +653,7 @@
             "name": "[variables('externalLBFEName')]",
             "properties": {
               "publicIPAddress": {
-                "id": "[variables('publicIPId')]"
+                "id": "[variables('publicIP1Id')]"
               }
             }
           }
@@ -624,6 +806,7 @@
           }
         ],
         "enableIPForwarding": true,
+        "enableAcceleratedNetworking": "[parameters('acceleratedNetworking')]",
         "networkSecurityGroup": {
           "id": "[variables('nsgId')]"
         }
@@ -670,6 +853,7 @@
           }
         ],
         "enableIPForwarding": true,
+        "enableAcceleratedNetworking": "[parameters('acceleratedNetworking')]",
         "networkSecurityGroup": {
           "id": "[variables('nsgId')]"
         }
@@ -681,7 +865,7 @@
       "name": "[variables('fgaNic2Name')]",
       "location": "[parameters('location')]",
       "tags": {
-       "provider": "[toUpper(parameters('fortinetTags').provider)]"
+        "provider": "[toUpper(parameters('fortinetTags').provider)]"
       },
       "dependsOn": [
         "[variables('internalLBId')]",
@@ -705,7 +889,11 @@
             }
           }
         ],
-        "enableIPForwarding": true
+        "enableIPForwarding": true,
+        "enableAcceleratedNetworking": "[parameters('acceleratedNetworking')]",
+        "networkSecurityGroup": {
+          "id": "[variables('nsgId')]"
+        }
       }
     },
     {
@@ -714,7 +902,7 @@
       "name": "[variables('fgbNic2Name')]",
       "location": "[parameters('location')]",
       "tags": {
-       "provider": "[toUpper(parameters('fortinetTags').provider)]"
+        "provider": "[toUpper(parameters('fortinetTags').provider)]"
       },
       "dependsOn": [
         "[variables('internalLBId')]",
@@ -739,25 +927,27 @@
             }
           }
         ],
-        "enableIPForwarding": true
+        "enableIPForwarding": true,
+        "enableAcceleratedNetworking": "[parameters('acceleratedNetworking')]",
+        "networkSecurityGroup": {
+          "id": "[variables('nsgId')]"
+        }
       }
     },
     {
-      "apiVersion": "2019-12-01",
+      "apiVersion": "2019-07-01",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('fgaVmName')]",
       "location": "[parameters('location')]",
       "tags": {
-       "provider": "[toUpper(parameters('fortinetTags').provider)]"
+        "provider": "[toUpper(parameters('fortinetTags').provider)]"
       },
       "identity": {
         "type": "SystemAssigned"
       },
-      "zones": [
-        "1"
-      ],
+      "zones": "[if(variables('useAZ'), variables('zone1'), json('null'))]",
       "plan": {
-        "name": "[parameters('fortigateImageSKU')]",
+        "name": "[parameters('fortiGateImageSKU')]",
         "publisher": "[variables('imagePublisher')]",
         "product": "[variables('imageOffer')]"
       },
@@ -769,18 +959,19 @@
         "hardwareProfile": {
           "vmSize": "[parameters('instanceType')]"
         },
+        "availabilitySet": "[if(not(variables('useAZ')), variables('availabilitySetId'), json('null'))]",
         "osProfile": {
           "computerName": "[variables('fgaVmName')]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]",
-          "customData": "[base64(concat('config system sdn-connector\nedit AzureSDN\nset type azure\nend\nend\nconfig system probe-response\n set mode http-probe\n end\n config router static\n edit 1\n set gateway ', variables('sn1GatewayIP'), '\n set device port1\n next\n edit 2\n set dst ', parameters('vnetAddressPrefix'), '\n set gateway ', variables('sn2GatewayIP'), '\n set device port2\n next\n edit 3\nset dst 168.63.129.16 255.255.255.255\nset device port2\n set gateway ', variables ('sn2GatewayIP'), '\n next\nedit 4\nset dst 168.63.129.16 255.255.255.255\nset device port1\n set gateway ', variables ('sn1GatewayIP'), '\n next\n end\n config system interface\n edit port1\n set mode static\n set ip ', variables('sn1IPfga'), '/', variables('sn1CIDRmask'), '\n set description external\n set allowaccess ping ssh https probe-response\n next\n edit port2\n set mode static\n set ip ', variables('sn2IPfga'), '/', variables('sn2CIDRmask'), '\n set description internal\n  set allowaccess ping ssh https probe-response\n next\n end'))]"
+          "customData": "[variables('fgaCustomData')]"
         },
         "storageProfile": {
           "imageReference": {
             "publisher": "[variables('imagePublisher')]",
             "offer": "[variables('imageOffer')]",
-            "sku": "[parameters('fortigateImageSKU')]",
-            "version": "[parameters('fortigateImageVersion')]"
+            "sku": "[parameters('fortiGateImageSKU')]",
+            "version": "[parameters('fortiGateImageVersion')]"
           },
           "osDisk": {
             "createOption": "FromImage"
@@ -812,21 +1003,19 @@
       }
     },
     {
-      "apiVersion": "2019-12-01",
+      "apiVersion": "2019-07-01",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('fgbVmName')]",
       "location": "[parameters('location')]",
       "tags": {
-       "provider": "[toUpper(parameters('fortinetTags').provider)]"
+        "provider": "[toUpper(parameters('fortinetTags').provider)]"
       },
       "identity": {
         "type": "SystemAssigned"
       },
-      "zones": [
-        "2"
-      ],
+      "zones": "[if(variables('useAZ'), variables('zone2'), json('null'))]",
       "plan": {
-        "name": "[parameters('fortigateImageSKU')]",
+        "name": "[parameters('fortiGateImageSKU')]",
         "publisher": "[variables('imagePublisher')]",
         "product": "[variables('imageOffer')]"
       },
@@ -838,18 +1027,19 @@
         "hardwareProfile": {
           "vmSize": "[parameters('instanceType')]"
         },
+        "availabilitySet": "[if(not(variables('useAZ')), variables('availabilitySetId'), json('null'))]",
         "osProfile": {
           "computerName": "[variables('fgbVmName')]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]",
-          "customData": "[base64(concat('config system sdn-connector\nedit AzureSDN\nset type azure\nend\nconfig system probe-response\n set mode http-probe\n end\n config router static\n edit 1\n set gateway ', variables('sn1GatewayIP'), '\n set device port1\n next\n edit 2\n set dst ', parameters('vnetAddressPrefix'), '\n set gateway ', variables('sn2GatewayIP'), '\n set device port2\n next\n edit 3\nset dst 168.63.129.16 255.255.255.255\nset device port2\n set gateway ', variables ('sn2GatewayIP'), '\n next\nedit 4\nset dst 168.63.129.16 255.255.255.255\nset device port1\n set gateway ', variables ('sn1GatewayIP'), '\n next\n end\n config system interface\n edit port1\n set mode static\n set ip ', variables('sn1IPfgb'), '/', variables('sn1CIDRmask'), '\n set description external\n set allowaccess ping ssh https probe-response\n next\n edit port2\n set mode static\n set ip ', variables('sn2IPfgb'), '/', variables('sn2CIDRmask'), '\n set description internal\n set allowaccess ping ssh https probe-response\n next\n end'))]"
+          "customData": "[variables('fgbCustomData')]"
         },
         "storageProfile": {
           "imageReference": {
             "publisher": "[variables('imagePublisher')]",
             "offer": "[variables('imageOffer')]",
-            "sku": "[parameters('fortigateImageSKU')]",
-            "version": "[parameters('fortigateImageVersion')]"
+            "sku": "[parameters('fortiGateImageSKU')]",
+            "version": "[parameters('fortiGateImageVersion')]"
           },
           "osDisk": {
             "createOption": "FromImage"
@@ -881,4 +1071,4 @@
       }
     }
   ]
-  }
+}

--- a/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/azuredeploy.parameters.json
+++ b/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/azuredeploy.parameters.json
@@ -3,30 +3,39 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "adminUsername": {
-            "value": "## TO BE DEFINED ##"
+            "value": ""
         },
         "adminPassword": {
-            "value": "## TO BE DEFINED ##"
+            "value": ""
         },
-        "FortiGateNamePrefix": {
-            "value": "## TO BE DEFINED ##"
+        "fortiGateNamePrefix": {
+            "value": ""
         },
-        "FortiGateImageSKU": {
+        "fortiGateImageSKU": {
             "value": "fortinet_fg-vm"
         },
-        "FortiGateImageVersion": {
+        "fortiGateImageVersion": {
             "value": "latest"
+        },
+        "fortiGateAditionalCustomData": {
+            "value": ""
         },
         "instanceType": {
             "value": "Standard_F2s"
         },
-        "publicIPNewOrExisting": {
+        "availabilityOptions": {
+            "value": "Availability Set"
+        },
+        "acceleratedNetworking": {
+            "value": "true"
+        },
+        "publicIP1NewOrExisting": {
             "value": "new"
         },
-        "publicIPName": {
+        "publicIP1Name": {
             "value": "FGTLBPublicIP"
         },
-        "publicIPResourceGroup": {
+        "publicIP1ResourceGroup": {
             "value": ""
         },
         "vnetNewOrExisting": {
@@ -42,10 +51,13 @@
             "value": "172.16.136.0/22"
         },
         "subnet1Name": {
-            "value": "ExteralSubnet"
+            "value": "ExternalSubnet"
         },
         "subnet1Prefix": {
             "value": "172.16.136.0/26"
+        },
+        "subnet1StartAddress": {
+            "value": "172.16.136.4"
         },
         "subnet2Name": {
             "value": "InternalSubnet"
@@ -53,19 +65,50 @@
         "subnet2Prefix": {
             "value": "172.16.136.64/26"
         },
+        "subnet2StartAddress": {
+            "value": "172.16.136.68"
+        },
         "subnet3Name": {
-            "value": "ProtectedSubnet"
+            "value": "ProtectedASubnet"
         },
         "subnet3Prefix": {
             "value": "172.16.137.0/24"
         },
+        "subnet4Name": {
+            "value": "ProtectedBSubnet"
+        },
+        "subnet4Prefix": {
+            "value": "172.16.138.0/24"
+        },
+        "fortiManager": {
+            "value": "no"
+        },
+        "fortiManagerIP": {
+            "value": ""
+        },
+        "fortiManagerSerial": {
+            "value": ""
+        },
+        "fortiGateLicenseBYOLA": {
+            "value": ""
+        },
+        "fortiGateLicenseBYOLB": {
+            "value": ""
+        },
+        "fortiGateLicenseFlexVMA": {
+            "value": ""
+        },
+        "fortiGateLicenseFlexVMB": {
+            "value": ""
+        },
         "location": {
             "value": "[resourceGroup().location]"
         },
-        "FortinetTags": {
+        "fortinetTags": {
             "value": {
                 "publisher": "Fortinet",
-                "provider": "6EB3B02F-50E5-4A3E-8CB8-2E12925831AA-AZ"
+                "template": "Active-Active-ELB-ILB-AZORAS",
+                "provider": "6EB3B02F-50E5-4A3E-8CB8-2E129258AAAZORAS"
             }
         }
     }

--- a/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/createUiDefinition.json
+++ b/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/createUiDefinition.json
@@ -191,8 +191,9 @@
 						"name": "instancetypeselection",
 						"type": "Microsoft.Compute.SizeSelector",
 						"label": "Size",
-						"toolTip": "Select the instance size of your FortiGate VM solution. Minimum 4 NICs are required.",
+						"toolTip": "Select the instance size of your FortiGate VM solution. Minimum 2 NICs are required.",
 						"recommendedSizes": [
+							"Standard_F2s",
 							"Standard_F1",
 							"Standard_F2",
 							"Standard_F4",

--- a/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/createUiDefinition.json
+++ b/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/createUiDefinition.json
@@ -1,0 +1,769 @@
+{
+	"$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+	"handler": "Microsoft.Azure.CreateUIDef",
+	"version": "0.1.2-preview",
+	"parameters": {
+		"config": {
+			"basics": {
+				"resourceGroup": {
+					"allowExisting": true
+				}
+			}
+		},
+		"resourceTypes": [
+			"microsoft.resources/resourcegroups"
+		],
+		"basics": [
+			{
+				"name": "adminUsername",
+				"type": "Microsoft.Common.TextBox",
+				"label": "FortiGate administrative username",
+				"defaultValue": "",
+				"toolTip": "Username for the FortiGate virtual appliance. May not be root, administrator or admin",
+				"constraints": {
+					"required": true,
+					"validations": [
+						{
+							"regex": "^[a-z0-9A-Z]{1,30}$",
+							"message": "Only alphanumeric characters are allowed, and the value must be 1-30 characters long"
+						},
+						{
+							"isValid": "[not(contains(toLower(basics('adminUsername')),'root'))]",
+							"message": "Usernames must not include reserved words"
+						},
+						{
+							"isValid": "[not(contains(toLower(basics('adminUsername')),'admin'))]",
+							"message": "Usernames must not include reserved words"
+						}
+					]
+				},
+				"visible": true
+			},
+			{
+				"name": "adminPassword",
+				"type": "Microsoft.Common.PasswordBox",
+				"label": {
+					"password": "FortiGate password",
+					"confirmPassword": "Confirm password"
+				},
+				"toolTip": "Password for the Virtual Machine",
+				"constraints": {
+					"required": true,
+					"regex": "^(?:(?=.*[a-z])(?:(?=.*[A-Z])(?=.*[\\d\\W])|(?=.*\\W)(?=.*\\d))|(?=.*\\W)(?=.*[A-Z])(?=.*\\d)).{12,}$",
+					"validationMessage": "The password must be between 12 characters and 72 characters, and contain characters from at least 3 of the following 4 complexity requirements: uppercase characters, lowercase characters, numbers, and special characters (regex match [\\W_])."
+				},
+				"options": {
+					"hideConfirmation": false
+				},
+				"visible": true
+			},
+			{
+				"name": "fortigateNamePrefix",
+				"type": "Microsoft.Common.TextBox",
+				"label": "FortiGate Name Prefix",
+				"defaultValue": "",
+				"toolTip": "Naming prefix for all deployed resources. The FortiGate VMs will have the suffix '-FGT-A' and '-FGT-B'. For example if the prefix is 'ACME-01' the FortiGates will be named 'ACME-01-FGT-A' and 'ACME-01-FGT-B'",
+				"constraints": {
+					"required": true,
+					"regex": "^[A-Za-z0-9]{1,15}$",
+					"validationMessage": "Only alphanumeric characters are allowed, and the value must be 1 to 15 characters."
+				},
+				"visible": true
+			},
+			{
+				"name": "fortigateImageSKU",
+				"type": "Microsoft.Common.DropDown",
+				"label": "FortiGate Image SKU",
+				"defaultValue": "Bring Your Own License",
+				"toolTip": "Identifies whether to to use PAYG (on demand licensing) or BYOL license model (where license is purchased separately)",
+				"constraints": {
+					"required": false,
+					"allowedValues": [
+						{
+							"label": "Bring Your Own License",
+							"value": "fortinet_fg-vm"
+						},
+						{
+							"label": "Pay As You Go",
+							"value": "fortinet_fg-vm_payg_20190624"
+						}
+					]
+				},
+				"visible": true
+			},
+			{
+				"name": "fortigateImageVersion",
+				"type": "Microsoft.Common.DropDown",
+				"label": "FortiGate Image Version",
+				"defaultValue": "latest",
+				"toolTip": "Select the FortiGate image version",
+				"constraints": {
+					"required": false,
+					"allowedValues": [
+						{
+							"label": "6.2.0",
+							"value": "6.2.0"
+						},
+						{
+							"label": "6.2.2",
+							"value": "6.2.2"
+						},
+						{
+							"label": "6.2.4",
+							"value": "6.2.4"
+						},
+						{
+							"label": "6.2.5",
+							"value": "6.2.5"
+						},
+						{
+							"label": "6.4.0",
+							"value": "6.4.0"
+						},
+						{
+							"label": "6.4.2",
+							"value": "6.4.2"
+						},
+						{
+							"label": "6.4.3",
+							"value": "6.4.3"
+						},
+						{
+							"label": "6.4.5",
+							"value": "6.4.5"
+						},
+						{
+							"label": "7.0.0",
+							"value": "7.0.0"
+						},
+						{
+							"label": "latest",
+							"value": "latest"
+						}
+					]
+				},
+				"visible": true
+			},
+			{
+				"name": "availabilityOptions",
+				"type": "Microsoft.Common.DropDown",
+				"label": "FortiGate Availability Options",
+				"defaultValue": "Availability Set",
+				"toolTip": "Deploy FortiGate VMs in an Availability Set or Availability Zones. If Availability Zones deployment is selected but the location does not support Availability Zones an Availability Set will be deployed. If Availability Zones deployment is selected and Availability Zones are available in the location, FortiGate A will be placed in Zone 1, FortiGate B will be placed in Zone 2",
+				"constraints": {
+					"required": false,
+					"allowedValues": [
+						{
+							"label": "Availability Set",
+							"value": "Availability Set"
+						},
+						{
+							"label": "Availability Zones",
+							"value": "Availability Zones"
+						}
+					]
+				},
+				"visible": true
+			}
+		],
+		"steps": [
+			{
+				"name": "instancetype",
+				"label": "Instance Type",
+				"subLabel": {
+					"preValidation": "Select instance type",
+					"postValidation": "Done"
+				},
+				"elements": [
+					{
+						"name": "instancetypeinfo",
+						"type": "Microsoft.Common.TextBlock",
+						"visible": true,
+						"options": {
+							"text": "For this FortiGate deployment, it is recommended to use the general purpose or compute optimized virtual machines. A selection of supported instances sizes is listed in our documentation.",
+							"link": {
+								"label": "Learn more",
+								"uri": "https://docs.fortinet.com/vm/azure/fortigate/7.0/azure-administration-guide/7.0.0/562841/instance-type-support"
+							}
+						}
+					},
+					{
+						"name": "instancetypeselection",
+						"type": "Microsoft.Compute.SizeSelector",
+						"label": "Size",
+						"toolTip": "Select the instance size of your FortiGate VM solution. Minimum 4 NICs are required.",
+						"recommendedSizes": [
+							"Standard_F1",
+							"Standard_F2",
+							"Standard_F4",
+							"Standard_F8",
+							"Standard_F16",
+							"Standard_F1s",
+							"Standard_F2s",
+							"Standard_F4s",
+							"Standard_F8s",
+							"Standard_F16s",
+							"Standard_F2s_v2",
+							"Standard_F4s_v2",
+							"Standard_F8s_v2",
+							"Standard_F16s_v2",
+							"Standard_F32s_v2",
+							"Standard_D1_v2",
+							"Standard_D2_v2",
+							"Standard_D3_v2",
+							"Standard_D4_v2",
+							"Standard_D5_v2",
+							"Standard_DS1_v2",
+							"Standard_DS2_v2",
+							"Standard_DS3_v2",
+							"Standard_DS4_v2",
+							"Standard_DS5_v2",
+							"Standard_D2_v3",
+							"Standard_D4_v3",
+							"Standard_D8_v3",
+							"Standard_D16_v3",
+							"Standard_D32_v3",
+							"Standard_D2s_v3",
+							"Standard_D4s_v3",
+							"Standard_D8s_v3",
+							"Standard_D16s_v3",
+							"Standard_D32s_v3"
+						],
+						"options": {
+							"hideDiskTypeFilter": false
+						},
+						"osPlatform": "Linux",
+						"imageReference": {
+							"publisher": "Fortinet",
+							"offer": "fortinet_fortigate-vm_v5",
+							"sku": "[basics('fortigateImageSKU')]"
+						},
+						"count": 2,
+						"visible": true
+					}
+				]
+			},
+			{
+				"name": "networking",
+				"label": "Networking",
+				"subLabel": {
+					"preValidation": "Configure internal networking",
+					"postValidation": "Done"
+				},
+				"elements": [
+					{
+						"name": "virtualnetworksection",
+						"type": "Microsoft.Common.Section",
+						"label": "Configure Internal Networking",
+						"elements": [
+							{
+								"name": "virtualnetworktext",
+								"type": "Microsoft.Common.TextBlock",
+								"visible": true,
+								"options": {
+									"text": "Create a new or select an existing virtual network with the required subnets. The internal subnet is a transit subnet containing only the FortiGate interfaces. Servers can be installed in a protected subnet with user defined routing configuration."
+								}
+							},
+							{
+								"name": "virtualnetwork",
+								"type": "Microsoft.Network.VirtualNetworkCombo",
+								"label": {
+									"virtualNetwork": "Virtual network",
+									"subnets": "Subnets"
+								},
+								"toolTip": {
+									"virtualNetwork": "Virtual Network for deployment of the FortiGate VM solution",
+									"subnets": "Standard deployment is to have external and internal subnets."
+								},
+								"defaultValue": {
+									"name": "FortiGate-VNET",
+									"addressPrefixSize": "/22"
+								},
+								"constraints": {
+									"minAddressPrefixSize": "/24"
+								},
+								"options": {
+									"hideExisting": false
+								},
+								"subnets": {
+									"subnet1": {
+										"label": "External Subnet",
+										"defaultValue": {
+											"name": "ExternalSubnet",
+											"addressPrefixSize": "/26"
+										},
+										"constraints": {
+											"minAddressPrefixSize": "/27",
+											"minAddressCount": 12,
+											"requireContiguousAddresses": true
+										}
+									},
+									"subnet2": {
+										"label": "Internal subnet",
+										"defaultValue": {
+											"name": "InternalSubnet",
+											"addressPrefixSize": "/26"
+										},
+										"constraints": {
+											"minAddressPrefixSize": "/27",
+											"minAddressCount": 8,
+											"requireContiguousAddresses": true
+										}
+									},
+									"subnet3": {
+										"label": "Protected A subnet",
+										"defaultValue": {
+											"name": "ProtectedASubnet",
+											"addressPrefixSize": "/24"
+										},
+										"constraints": {
+											"minAddressPrefixSize": "/27",
+											"minAddressCount": 8,
+											"requireContiguousAddresses": true
+										}
+									},
+									"subnet4": {
+										"label": "Protectet B subnet",
+										"defaultValue": {
+											"name": "ProtectedBSubnet",
+											"addressPrefixSize": "/24"
+										},
+										"constraints": {
+											"minAddressPrefixSize": "/27",
+											"minAddressCount": 8,
+											"requireContiguousAddresses": true
+										}
+									}
+								},
+								"visible": true
+							},
+							{
+								"name": "virtualnetworkinfo",
+								"type": "Microsoft.Common.InfoBox",
+								"visible": true,
+								"options": {
+									"icon": "Info",
+									"text": "The internal subnet is a transit subnet containing only the FortiGate interfaces for traffic to and from the internal networks. Internal systems should be installed in a protected subnet with user defined route configuration.",
+									"uri": "https://github.com/fortinet/azure-templates/tree/main/FortiGate/Active-Active-ELB-ILB"
+								}
+							}
+						]
+					},
+					{
+						"name": "acceleratednetworksection",
+						"type": "Microsoft.Common.Section",
+						"label": "Accelerated networking",
+						"elements": [
+							{
+								"name": "acceleratednetworkingtext",
+								"type": "Microsoft.Common.TextBlock",
+								"visible": true,
+								"options": {
+									"text": "Enables SR-IOV support allowing direct acces from the NIC in the Azure infrastructure to the FortiGate VM.",
+									"link": {
+										"label": "Learn more",
+										"uri": "https://docs.fortinet.com/vm/azure/fortigate/7.0/azure-administration-guide/7.0.0/651644/enabling-accelerated-networking-on-the-fortigate-vm"
+									}
+								}
+							},
+							{
+								"name": "acceleratednetworking",
+								"type": "Microsoft.Common.OptionsGroup",
+								"label": "Accelerated Networking",
+								"defaultValue": "Enabled",
+								"toolTip": "Accelerated Networking enables direct connection between the VM and network card. Only available on 2 CPU F/Fs and 4 CPU D/Dsv2, D/Dsv3, E/Esv3, Fsv2, Lsv2, Ms/Mms and Ms/Mmsv2",
+								"constraints": {
+									"required": false,
+									"allowedValues": [
+										{
+											"label": "Enabled",
+											"value": "true"
+										},
+										{
+											"label": "Disabled",
+											"value": "false"
+										}
+									]
+								},
+								"visible": true
+							},
+							{
+								"name": "acceleratednetworkinginfo",
+								"type": "Microsoft.Common.InfoBox",
+								"visible": true,
+								"options": {
+									"icon": "Info",
+									"text": "Accelerated Networking is supported on most general purpose and compute-optimized instance sizes with 2 or more vCPUs. On instances that support hyperthreading, Accelerated Networking is supported on VM instances with 4 or more vCPUs. Deployment with the accelerated networking feature enabled on a host that doesn't support it will result in a failure to connect to it. The accelerated networking can be disabled after deployment from the Azure Portal or Azure CLI.",
+									"uri": "https://docs.microsoft.com/en-us/azure/virtual-machines/sizes"
+								}
+							}
+						]
+					}
+				]
+			},
+			{
+				"name": "publicip",
+				"label": "Public IP",
+				"subLabel": {
+					"preValidation": "Configure public networking",
+					"postValidation": "Done"
+				},
+				"elements": [
+					{
+						"name": "publiciptext",
+						"type": "Microsoft.Common.TextBlock",
+						"visible": true,
+						"options": {
+							"text": "The Load Balancer public IP will be used for public services hosted on the FortiGate such as IPSEC termination or services behind the Fortigate such as a webserver. The FortiGate Management public IPs are used for management of the virtual machines. They are also used for the Fabric connector to retrieve information from the Azure platform."
+						}
+					},
+					{
+						"name": "loadbalancerpublicip",
+						"type": "Microsoft.Network.PublicIpAddressCombo",
+						"label": {
+							"publicIpAddress": "Public IP address",
+							"domainNameLabel": "Domain name label"
+						},
+						"toolTip": {
+							"publicIpAddress": "Public IP attached to the public load balancer",
+							"domainNameLabel": "DNS name linked to this public IP"
+						},
+						"defaultValue": {
+							"publicIpAddressName": "FGTPublicIP",
+							"domainNameLabel": "mydomain"
+						},
+						"constraints": {
+							"required": {
+								"domainNameLabel": false
+							}
+						},
+						"options": {
+							"hideNone": true,
+							"hideDomainNameLabel": true
+						},
+						"visible": true
+					},
+					{
+						"name": "standardsku",
+						"type": "Microsoft.Common.InfoBox",
+						"visible": true,
+						"options": {
+							"icon": "Info",
+							"text": "This deployment uses a Standard SKU Azure Load Balancer and requires a Standard SKU public IP. Microsoft Azure offers a migration path from a basic to standard SKU public IP.",
+							"uri": "https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-public-ip-address-upgrade?tabs=option-upgrade-cli%2Coption-migrate-powershell"
+						}
+					}
+				]
+			},
+			{
+				"name": "publicipreview",
+				"label": "Public IP Verification",
+				"subLabel": {
+					"preValidation": "Public IP SKU Review",
+					"postValidation": "Done"
+				},
+				"bladeTitle": "Public IP SKU Review",
+				"elements": [
+					{
+						"name": "BasicIPWarning1",
+						"type": "Microsoft.Common.InfoBox",
+						"options": {
+							"icon": "Error",
+							"text": "The External Load Balancer Public IP is configured using Basic SKU. Please return to previous blade and use Standard type public IPs to support Azure Standard Load Balancers"
+						},
+						"visible": "[not(equals(steps('publicip').loadbalancerpublicip.sku, 'Standard'))]"
+					},
+					{
+						"name": "StandardIPConfirmation1",
+						"type": "Microsoft.Common.InfoBox",
+						"options": {
+							"icon": "Info",
+							"text": "The External Load Balancer Public IP is Standard SKU. Proceed."
+						},
+						"visible": "[equals(steps('publicip').loadbalancerpublicip.sku, 'Standard')]"
+					},
+					{
+						"name": "BasicIPWarning2",
+						"type": "Microsoft.Common.InfoBox",
+						"options": {
+							"icon": "Error",
+							"text": "The FortiGate A management Public IP is configured using Basic SKU. Please return to previous blade and use Standard type public IPs to support Azure Standard Load Balancers"
+						},
+						"visible": "[not(equals(steps('publicip').fgtamgmtpublicip.sku, 'Standard'))]"
+					},
+					{
+						"name": "StandardIPConfirmation2",
+						"type": "Microsoft.Common.InfoBox",
+						"options": {
+							"icon": "Info",
+							"text": "The FortiGate A management Public IP is Standard SKU. Proceed."
+						},
+						"visible": "[equals(steps('publicip').fgtamgmtpublicip.sku, 'Standard')]"
+					},
+					{
+						"name": "BasicIPWarning3",
+						"type": "Microsoft.Common.InfoBox",
+						"options": {
+							"icon": "Error",
+							"text": "The FortiGate B management Public IP is configured using Basic SKU. Please return to previous blade and use Standard type public IPs to support Azure Standard Load Balancers"
+						},
+						"visible": "[not(equals(steps('publicip').fgtbmgmtpublicip.sku, 'Standard'))]"
+					},
+					{
+						"name": "StandardIPConfirmation3",
+						"type": "Microsoft.Common.InfoBox",
+						"options": {
+							"icon": "Info",
+							"text": "The FortiGate B management Public IP is Standard SKU. Proceed."
+						},
+						"visible": "[equals(steps('publicip').fgtbmgmtpublicip.sku, 'Standard')]"
+					}
+				]
+			},
+			{
+				"name": "advanced",
+				"label": "Advanced",
+				"subLabel": {
+					"preValidation": "Configure central management",
+					"postValidation": "Done"
+				},
+				"elements": [
+					{
+						"name": "fortimanager",
+						"type": "Microsoft.Common.Section",
+						"label": "FortiManager",
+						"elements": [
+							{
+								"name": "fortimanagertext",
+								"type": "Microsoft.Common.TextBlock",
+								"visible": true,
+								"options": {
+									"text": "Connect to FortiManager"
+								}
+							},
+							{
+								"name": "enabled",
+								"type": "Microsoft.Common.OptionsGroup",
+								"label": "Connect to FortiManager",
+								"defaultValue": "no",
+								"toolTip": "FortiManager needs to be reachable from port 1 or port 2 of the FortiGate",
+								"constraints": {
+									"allowedValues": [
+										{
+											"label": "yes",
+											"value": "yes"
+										},
+										{
+											"label": "no",
+											"value": "no"
+										}
+									],
+									"required": true
+								},
+								"visible": true
+							},
+							{
+								"name": "fortimanagerip",
+								"type": "Microsoft.Common.TextBox",
+								"label": "FortiManager IP address",
+								"defaultValue": "",
+								"toolTip": "Provide the IP address or DNS name of the FortiManager reachable over port TCP/541",
+								"constraints": {
+									"required": false,
+									"regex": "^[A-Za-z0-9.]{1,64}$",
+									"validationMessage": "Only alphanumeric characters and dots are allowed, and the value must be 1 to 64 characters."
+								},
+								"visible": true
+							},
+							{
+								"name": "fortimanagerserial",
+								"type": "Microsoft.Common.TextBox",
+								"label": "FortiManager Serial Number",
+								"defaultValue": "",
+								"toolTip": "Provide the serial number of the FortiManager",
+								"constraints": {
+									"required": false,
+									"regex": "^[A-Za-z0-9-]{1,64}$",
+									"validationMessage": "Only alphanumeric characters and a dash are allowed, and the value must be 1 to 64 characters."
+								},
+								"visible": true
+							}
+						],
+						"visible": true
+					},
+					{
+						"name": "customdata",
+						"type": "Microsoft.Common.Section",
+						"label": "Custom Data",
+						"elements": [
+							{
+								"name": "customdatatext",
+								"type": "Microsoft.Common.TextBlock",
+								"visible": true,
+								"options": {
+									"text": "Pass configuration data into the virtual machine while it is being provisioned. This is additional to the configuration for this architecture."
+								}
+							},
+							{
+								"name": "config",
+								"type": "Microsoft.Common.TextBox",
+								"label": "Custom Data",
+								"toolTip": "Custom Data",
+								"placeholder": "Add your required additional configuration here.",
+								"multiLine": true,
+								"constraints": {
+									"required": false,
+									"validations": [
+										{
+											"regex": "^[\\w\\W\n\t]{0,10240}$",
+											"message": "All characters allowed, max 10240 characters."
+										}
+									]
+								},
+								"visible": true
+							},
+							{
+								"name": "standardsku",
+								"type": "Microsoft.Common.InfoBox",
+								"visible": true,
+								"options": {
+									"icon": "Info",
+									"text": "The default configuration already included in this deployment can be found on our github page. ",
+									"uri": "https://github.com/fortinet/azure-templates/blob/main/FortiGate/Active-Active-ELB-ILB/doc/config-provisioning.md"
+								}
+							}
+						]
+					},
+					{
+						"name": "fgtlicense",
+						"type": "Microsoft.Common.Section",
+						"label": "FortiGate License",
+						"elements": [
+							{
+								"name": "customdatatext",
+								"type": "Microsoft.Common.TextBlock",
+								"visible": true,
+								"options": {
+									"text": "When using BYOL, you can upload the license file retrieved from support.fortinet.com here."
+								}
+							},
+							{
+								"name": "licenseacontent",
+								"type": "Microsoft.Common.FileUpload",
+								"label": "FortiGate A License",
+								"toolTip": "Upload the license file for the primary FortiGate BYOL here.",
+								"constraints": {
+									"required": false,
+									"accept": ".lic,.txt"
+								},
+								"options": {
+									"multiple": false,
+									"uploadMode": "file",
+									"openMode": "text",
+									"encoding": "UTF-8"
+								},
+								"visible": true
+							},
+							{
+								"name": "licensebcontent",
+								"type": "Microsoft.Common.FileUpload",
+								"label": "FortiGate B License",
+								"toolTip": "Upload the license file for the secondary FortiGate BYOL here.",
+								"constraints": {
+									"required": false,
+									"accept": ".lic,.txt"
+								},
+								"options": {
+									"multiple": false,
+									"uploadMode": "file",
+									"openMode": "text",
+									"encoding": "UTF-8"
+								},
+								"visible": true
+							},
+							{
+								"name": "skuPaygWarning",
+								"type": "Microsoft.Common.InfoBox",
+								"options": {
+									"icon": "Warning",
+									"text": "Pay as you go licenses was selected in the basics blade. The licenses uploaded here will not be used."
+								},
+								"visible": "[not(equals(basics('fortigateImageSKU'), 'fortinet_fg-vm'))]"
+							},
+							{
+								"name": "licenseflexvmtext",
+								"type": "Microsoft.Common.TextBlock",
+								"visible": true,
+								"options": {
+									"text": "When your organisation is subscribed to Flex-VM you can provide the licenses token here."
+								}
+							},
+							{
+								"name": "licenseaflexvmtoken",
+								"type": "Microsoft.Common.TextBox",
+								"label": "FortiGate A Flex-VM",
+								"defaultValue": "",
+								"toolTip": "FortiGate A Flex-VM license token",
+								"constraints": {
+									"required": false,
+									"regex": "^[A-Za-z0-9-]{1,64}$",
+									"validationMessage": "Only alphanumeric characters and a dash are allowed, and the value must be 1 to 64 characters."
+								},
+								"visible": true
+							},
+							{
+								"name": "licensebflexvmtoken",
+								"type": "Microsoft.Common.TextBox",
+								"label": "FortiGate B Flex-VM",
+								"defaultValue": "",
+								"toolTip": "FortiGate B Flex-VM license token",
+								"constraints": {
+									"required": false,
+									"regex": "^[A-Za-z0-9-]{1,64}$",
+									"validationMessage": "Only alphanumeric characters and a dash are allowed, and the value must be 1 to 64 characters."
+								},
+								"visible": true
+							}
+						]
+					}
+				]
+			}
+		],
+		"outputs": {
+			"fortiGateNamePrefix": "[basics('fortigateNamePrefix')]",
+			"fortiGateImageSKU": "[basics('fortigateImageSKU')]",
+			"fortiGateImageVersion": "[basics('fortigateImageVersion')]",
+			"adminUsername": "[basics('adminUsername')]",
+			"adminPassword": "[basics('adminPassword')]",
+			"availabilityOptions": "[basics('availabilityOptions')]",
+			"location": "[location()]",
+			"instanceType": "[steps('instancetype').instancetypeselection]",
+			"acceleratedNetworking": "[steps('networking').acceleratednetworksection.acceleratednetworking]",
+			"publicIP1NewOrExisting": "[steps('publicip').loadbalancerpublicip.newOrExistingOrNone]",
+			"publicIP1Name": "[steps('publicip').loadbalancerpublicip.name]",
+			"publicIPResourceGroup": "[steps('publicip').loadbalancerpublicip.resourceGroup]",
+			"vnetNewOrExisting": "[steps('networking').virtualnetworksection.virtualnetwork.newOrExisting]",
+			"vnetName": "[steps('networking').virtualnetworksection.virtualnetwork.name]",
+			"vnetResourceGroup": "[steps('networking').virtualnetworksection.virtualnetwork.resourceGroup]",
+			"vnetAddressPrefix": "[steps('networking').virtualnetworksection.virtualnetwork.addressPrefix]",
+			"subnet1Name": "[steps('networking').virtualnetworksection.virtualnetwork.subnets.subnet1.name]",
+			"subnet1Prefix": "[steps('networking').virtualnetworksection.virtualnetwork.subnets.subnet1.addressPrefix]",
+			"subnet1StartAddress": "[steps('networking').virtualnetworksection.virtualnetwork.subnets.subnet1.startAddress]",
+			"subnet2Name": "[steps('networking').virtualnetworksection.virtualnetwork.subnets.subnet2.name]",
+			"subnet2Prefix": "[steps('networking').virtualnetworksection.virtualnetwork.subnets.subnet2.addressPrefix]",
+			"subnet2StartAddress": "[steps('networking').virtualnetworksection.virtualnetwork.subnets.subnet2.startAddress]",
+			"subnet3Name": "[steps('networking').virtualnetworksection.virtualnetwork.subnets.subnet3.name]",
+			"subnet3Prefix": "[steps('networking').virtualnetworksection.virtualnetwork.subnets.subnet3.addressPrefix]",
+			"subnet4Name": "[steps('networking').virtualnetworksection.virtualnetwork.subnets.subnet4.name]",
+			"subnet4Prefix": "[steps('networking').virtualnetworksection.virtualnetwork.subnets.subnet4.addressPrefix]",
+			"fortiManager": "[steps('advanced').fortimanager.enabled]",
+			"fortiManagerIP": "[steps('advanced').fortimanager.fortimanagerip]",
+			"fortiManagerSerial": "[steps('advanced').fortimanager.fortimanagerserial]",
+			"fortiGateAditionalCustomData": "[steps('advanced').customdata.config]",
+			"fortiGateLicenseBYOLA": "[steps('advanced').fgtlicense.licenseacontent]",
+			"fortiGateLicenseBYOLB": "[steps('advanced').fgtlicense.licensebcontent]",
+			"fortiGateLicenseFlexVMA": "[steps('advanced').fgtlicense.licenseaflexvmtoken]",
+			"fortiGateLicenseFlexVMB": "[steps('advanced').fgtlicense.licensebflexvmtoken]"
+		}
+	}
+}

--- a/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/deploy.sh
+++ b/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/deploy.sh
@@ -4,12 +4,13 @@ echo "
 #
 # Fortinet FortiGate ARM deployment template
 # Active/Active loadbalanced pair of standalone FortiGates for resilience and scale using Availability Zones
+# or an Availability Set
 #
 ##############################################################################################################
 
 "
 #echo "--> Auto accepting terms for Azure Marketplace deployments ..."
-#az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm
+#az vm image terms accept --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm
 
 # Stop on error
 set +e
@@ -92,8 +93,8 @@ az group create --location "$location" --name "$rg"
 # Validate template
 echo "--> Validation deployment in $rg resource group ..."
 az deployment group validate --resource-group "$rg" \
-                           --template-file azuredeploy.json \
-                           --parameters adminUsername="$username" adminPassword=$passwd FortiGateNamePrefix=$prefix
+                        --template-file azuredeploy.json \
+                        --parameters adminUsername="$username" adminPassword=$passwd fortigateNamePrefix=$prefix
 result=$?
 if [ $result != 0 ];
 then
@@ -103,9 +104,9 @@ fi
 
 # Deploy resources
 echo "--> Deployment of $rg resources ..."
-az deployment group create --resource-group "$rg" \
-                           --template-file azuredeploy.json \
-                           --parameters adminUsername="$username" adminPassword=$password FortiGateNamePrefix=$prefix
+az deployment group create --confirm-with-what-if --resource-group "$rg" \
+                        --template-file azuredeploy.json \
+                        --parameters adminUsername="$username" adminPassword=$passwd fortigateNamePrefix=$prefix
 result=$?
 if [[ $result != 0 ]];
 then
@@ -117,6 +118,7 @@ echo "
 #
 # FortiGate Azure deployment using ARM Template
 # Active/Active loadbalanced pair of standalone FortiGates for resilience and scale using Availability Zones
+# or an Availability Set
 #
 # You can access both management GUIs and SSH using the public IP address of the load balancer using HTTPS on
 # port 40030, 40031 and for SSH on port 50030 and 50031. The FortiGate VMs are also acessible using their
@@ -132,8 +134,7 @@ FortiGate IP addesses
 "
 query="[?virtualMachine.name.starts_with(@, '$prefix')].{virtualMachine:virtualMachine.name, publicIP:virtualMachine.network.publicIpAddresses[0].ipAddress,privateIP:virtualMachine.network.privateIpAddresses[0]}"
 az vm list-ip-addresses --query "$query" --output tsv
-echo "
- IP Public Azure Load Balancer:"
+echo "IP Public Azure Load Balancer:"
 publicIpIds=$(az network lb show -g "$rg" -n "$prefix-ExternalLoadBalancer" --query "frontendIpConfigurations[].publicIpAddress.id" --out tsv)
 while read publicIpId; do
     az network public-ip show --ids "$publicIpId" --query "{ ipAddress: ipAddress, fqdn: dnsSettings.fqdn }" --out tsv

--- a/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/metadata.json
+++ b/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/metadata.json
@@ -1,9 +1,9 @@
 {
     "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
     "type": "QuickStart",
-    "itemDisplayName": "Fortinet FortiGate Active Active cluster using the Azure Standard Load Balancer in Availability Zones",
+    "itemDisplayName": "Fortinet FortiGate Active Active cluster using the Azure Standard Load Balancer in Availability Zones or an Availability Set",
     "description": "This Azure quickstart template deploys 2 FortiGate VM's with the required network infrastructure, routing and load balancers",
     "summary": "This Azure quickstart template deploys 2 FortiGate VM's with the required network infrastructure, routing and load balancers",
     "githubUsername": "40net-cloud",
-    "dateUpdated":  "2021-01-12"
+    "dateUpdated":  "2021-06-28"
 }

--- a/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/test/azuredeploy.tests.ps1
+++ b/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/test/azuredeploy.tests.ps1
@@ -63,6 +63,7 @@ Describe 'FGT A/A' {
 
         It 'Creates the expected Azure resources' {
             $expectedResources = 'Microsoft.Resources/deployments',
+                                 'Microsoft.Compute/availabilitySets',
                                  'Microsoft.Network/virtualNetworks',
                                  'Microsoft.Network/loadBalancers',
                                  'Microsoft.Network/routeTables',
@@ -80,28 +81,41 @@ Describe 'FGT A/A' {
         }
 
         It 'Contains the expected parameters' {
-            $expectedTemplateParameters = 'adminPassword',
-                                          'adminUsername',
-                                          'fortigateImageSKU',
-                                          'fortigateImageVersion',
-                                          'fortigateNamePrefix',
-                                          'fortinetTags',
-                                          'instanceType',
-                                          'location',
-                                          'publicIPAddressType',
-                                          'publicIPName',
-                                          'publicIPNewOrExisting',
-                                          'publicIPResourceGroup',
-                                          'subnet1Name',
-                                          'subnet1Prefix',
-                                          'subnet2Name',
-                                          'subnet2Prefix',
-                                          'subnet3Name',
-                                          'subnet3Prefix',
-                                          'vnetAddressPrefix',
-                                          'vnetName',
-                                          'vnetNewOrExisting',
-                                          'vnetResourceGroup'
+            $expectedTemplateParameters =   'adminUsername',
+                                            'adminPassword',
+                                            'fortiGateNamePrefix',
+                                            'fortiGateImageSKU',
+                                            'fortiGateImageVersion',
+                                            'fortiGateAditionalCustomData',
+                                            'instanceType',
+                                            'availabilityOptions',
+                                            'acceleratedNetworking',
+                                            'publicIP1NewOrExisting',
+                                            'publicIP1Name',
+                                            'publicIP1ResourceGroup',
+                                            'vnetNewOrExisting',
+                                            'vnetName',
+                                            'vnetResourceGroup',
+                                            'vnetAddressPrefix',
+                                            'subnet1Name',
+                                            'subnet1Prefix',
+                                            'subnet1StartAddress',
+                                            'subnet2Name',
+                                            'subnet2Prefix',
+                                            'subnet2StartAddress',
+                                            'subnet3Name',
+                                            'subnet3Prefix',
+                                            'subnet4Name',
+                                            'subnet4Prefix',
+                                            'fortiManager',
+                                            'fortiManagerIP',
+                                            'fortiManagerSerial',
+                                            'fortiGateLicenseBYOLA',
+                                            'fortiGateLicenseBYOLB',
+                                            'fortiGateLicenseFlexVMA',
+                                            'fortiGateLicenseFlexVMB',
+                                            'location',
+                                            'fortinetTags'
             $templateParameters = (get-content $templateFileLocation | ConvertFrom-Json -ErrorAction SilentlyContinue).Parameters | Get-Member -MemberType NoteProperty | % Name | sort
             $templateParameters | Should Be $expectedTemplateParameters
         }
@@ -119,7 +133,7 @@ Describe 'FGT A/A' {
 
         $params = @{ 'adminUsername'=$testsAdminUsername
                      'adminPassword'=$testsResourceGroupName
-                     'fortigateNamePrefix'=$testsPrefix
+                     'FortiGateNamePrefix'=$testsPrefix
                     }
         $publicIPName = "FGTLBPublicIP"
         $publicIP2Name = "FGTLBPublicIP2"
@@ -142,7 +156,7 @@ Describe 'FGT A/A' {
         40030, 50030, 40031, 50031 | Foreach-Object {
             it "Port [$_] is listening" {
                 $result = Get-AzPublicIpAddress -Name $publicIPName -ResourceGroupName $testsResourceGroupName
-                $portListening = (Test-NetConnection -Port $_ -ComputerName $result.IpAddress).TcpTestSucceeded
+                $portListening = (Test-Connection -TargetName $result.IpAddress -TCPPort $_ -TimeoutSeconds 100)
                 $portListening | Should -Be $true
             }
         }

--- a/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/test/invokePester.ps1
+++ b/FortiGate/AvailabilityZones/Active-Active-ELB-ILB-AZ/test/invokePester.ps1
@@ -21,7 +21,7 @@ if (-not(Test-Path $modulePath)) {
 
 Import-Module $modulePath -DisableNameChecking
 
-$modulePath = Join-Path $TempDir Pester-master\Pester.psm1
+$modulePath = Join-Path $TempDir Pester-main/Pester.psm1
 
 if (-not(Test-Path $modulePath)) {
 
@@ -55,7 +55,6 @@ $outputFile = Join-Path $SourceDir "TEST-armttk.xml";
 $results = @(Test-AzTemplate -TemplatePath $SourceDir)
 $results
 Export-NUnitXml -TestResults $results -Path $SourceDir
-dir $SourceDir
 
 $outputFile = Join-Path $SourceDir "TEST-custom.xml";
 


### PR DESCRIPTION
Update AA ELB ILB Availability Zones Template to support either Availability Zones or Availability Sets

Updated

- Parameters - for example, publicIPName became publicIP1Name - for future looping constructs
- Parameter descriptions
- Added Variables to support AZ vs. AS selection and deployment
- README.md, before/after merge "Deploy to Azure" button links need to be updated to support organization, branch and repository. 

Added Parameter "Availability Options"
Options
- Availability Set <-- this is the default
- Availability Zones
Choice outcomes

User picks "Availability Set" in an AZ supported region - VMs are deployed to an AS because that is what the user has specified.
User picks "Availability Zones" in an AZ supported region - VMs are deployed to AZ 1 and AZ 2 because that is what the user has specified.
User picks "Availability Zones" in a region that does not support AZs - VMs are deployed to an AS because that is what the region supports - no error message or indication of AS utilization is supplied. Since the default parameter choice is AS this should be a rare occurrence.

