### PR TITLE
Bugfix: Removed no longer existing parameters and fixed a typo

### DIFF
--- a/FortiGate/Terraform/Active-Passive-ELB-ILB/terraform/02-fortigate.tf
+++ b/FortiGate/Terraform/Active-Passive-ELB-ILB/terraform/02-fortigate.tf
@@ -73,14 +73,12 @@ resource "azurerm_lb_backend_address_pool" "elbbackend" {
 }
 
 resource "azurerm_lb_probe" "elbprobe" {
-  resource_group_name = azurerm_resource_group.resourcegroup.name
   loadbalancer_id     = azurerm_lb.elb.id
   name                = "lbprobe"
   port                = 8008
 }
 
 resource "azurerm_lb_rule" "lbruletcp" {
-  resource_group_name            = azurerm_resource_group.resourcegroup.name
   loadbalancer_id                = azurerm_lb.elb.id
   name                           = "PublicLBRule-FE1-http"
   protocol                       = "Tcp"
@@ -92,7 +90,6 @@ resource "azurerm_lb_rule" "lbruletcp" {
 }
 
 resource "azurerm_lb_rule" "lbruleudp" {
-  resource_group_name            = azurerm_resource_group.resourcegroup.name
   loadbalancer_id                = azurerm_lb.elb.id
   name                           = "PublicLBRule-FE1-udp10551"
   protocol                       = "Udp"
@@ -123,14 +120,12 @@ resource "azurerm_lb_backend_address_pool" "ilbbackend" {
 }
 
 resource "azurerm_lb_probe" "ilbprobe" {
-  resource_group_name = azurerm_resource_group.resourcegroup.name
   loadbalancer_id     = azurerm_lb.ilb.id
   name                = "lbprobe"
   port                = 8008
 }
 
 resource "azurerm_lb_rule" "lb_haports_rule" {
-  resource_group_name            = azurerm_resource_group.resourcegroup.name
   loadbalancer_id                = azurerm_lb.ilb.id
   name                           = "lb_haports_rule"
   protocol                       = "All"
@@ -151,7 +146,7 @@ resource "azurerm_network_interface" "fgtaifcext" {
   ip_configuration {
     name                          = "interface1"
     subnet_id                     = azurerm_subnet.subnet1.id
-    private_ip_address_allocation = "static"
+    private_ip_address_allocation = "Static"
     private_ip_address            = var.fgt_ipaddress_a["1"]
   }
 }
@@ -176,7 +171,7 @@ resource "azurerm_network_interface" "fgtaifcint" {
   ip_configuration {
     name                          = "interface1"
     subnet_id                     = azurerm_subnet.subnet2.id
-    private_ip_address_allocation = "static"
+    private_ip_address_allocation = "Static"
     private_ip_address            = var.fgt_ipaddress_a["2"]
   }
 }
@@ -201,7 +196,7 @@ resource "azurerm_network_interface" "fgtaifchasync" {
   ip_configuration {
     name                          = "interface1"
     subnet_id                     = azurerm_subnet.subnet3.id
-    private_ip_address_allocation = "static"
+    private_ip_address_allocation = "Static"
     private_ip_address            = var.fgt_ipaddress_a["3"]
   }
 }
@@ -230,7 +225,7 @@ resource "azurerm_network_interface" "fgtaifcmgmt" {
   ip_configuration {
     name                          = "interface1"
     subnet_id                     = azurerm_subnet.subnet4.id
-    private_ip_address_allocation = "static"
+    private_ip_address_allocation = "Static"
     private_ip_address            = var.fgt_ipaddress_a["4"]
     public_ip_address_id          = azurerm_public_ip.fgtamgmtpip.id
   }
@@ -336,7 +331,7 @@ resource "azurerm_network_interface" "fgtbifcext" {
   ip_configuration {
     name                          = "interface1"
     subnet_id                     = azurerm_subnet.subnet1.id
-    private_ip_address_allocation = "static"
+    private_ip_address_allocation = "Static"
     private_ip_address            = var.fgt_ipaddress_b["1"]
   }
 }
@@ -362,7 +357,7 @@ resource "azurerm_network_interface" "fgtbifcint" {
   ip_configuration {
     name                          = "interface1"
     subnet_id                     = azurerm_subnet.subnet2.id
-    private_ip_address_allocation = "static"
+    private_ip_address_allocation = "Static"
     private_ip_address            = var.fgt_ipaddress_b["2"]
   }
 }
@@ -388,7 +383,7 @@ resource "azurerm_network_interface" "fgtbifchasync" {
   ip_configuration {
     name                          = "interface1"
     subnet_id                     = azurerm_subnet.subnet3.id
-    private_ip_address_allocation = "static"
+    private_ip_address_allocation = "Static"
     private_ip_address            = var.fgt_ipaddress_b["3"]
   }
 }
@@ -417,7 +412,7 @@ resource "azurerm_network_interface" "fgtbifcmgmt" {
   ip_configuration {
     name                          = "interface1"
     subnet_id                     = azurerm_subnet.subnet4.id
-    private_ip_address_allocation = "static"
+    private_ip_address_allocation = "Static"
     private_ip_address            = var.fgt_ipaddress_b["4"]
     public_ip_address_id          = azurerm_public_ip.fgtbmgmtpip.id
   }


### PR DESCRIPTION
Hi,

I tried to deploy the provided terraform configuration in `FortiGate/Terraform/Active-Passive-ELB-ILB/` but encountered a few minor errors that result from parameters that no longer exist in the specified resources and a recurring typo.
With the provided changes the deployment is now functional again.   