### PR TITLE
Update az vm image accept terms command /  Use primary/secondary keywords in A/A auto-scale config

### DIFF
--- a/FortiGate/A-Single-VM/README.md
+++ b/FortiGate/A-Single-VM/README.md
@@ -66,9 +66,9 @@ The ARM template deploys different resources and it is required to have the acce
   - It needs to contain characters from at least 3 of the following groups: uppercase characters, lowercase characters, numbers, and special characters excluding '\' or '-'
 - The terms for the FortiGate PAYG or BYOL image in the Azure Marketplace needs to be accepted once before usage. This is done automatically during deployment via the Azure Portal. For the Azure CLI the commands below need to be run before the first deployment in a subscription.
   - BYOL
-`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm`
+`az vm image terms accept --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm`
   - PAYG
-`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm_payg_20190624`
+`az vm image terms accept --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm_payg_2022`
 
 ## FortiGate configuration
 

--- a/FortiGate/Active-Active-ELB-ILB/README.md
+++ b/FortiGate/Active-Active-ELB-ILB/README.md
@@ -74,10 +74,10 @@ The ARM template deploys different resources and it is required to have the acce
   - It must be 12 characters or longer
   - It needs to contain characters from at least 3 of the following groups: uppercase characters, lowercase characters, numbers, and special characters excluding '\' or '-'
 - The terms for the FortiGate PAYG or BYOL image in the Azure Marketplace needs to be accepted once before usage. This is done automatically during deployment via the Azure Portal. For the Azure CLI the commands below need to be run before the first deployment in a subscription.
-  - BYOL:
-`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm`
-  - PAYG:
-`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm_payg_20190624`
+  - BYOL
+`az vm image terms accept --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm`
+  - PAYG
+`az vm image terms accept --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm_payg_2022`
 
 ## FortiGate configuration
 
@@ -128,7 +128,7 @@ FortiGate A
 ```text
 config system auto-scale
     set status enable
-    set role master
+    set role primary
     set sync-interface "port2"
     set psksecret "a big secret"
 end
@@ -139,8 +139,9 @@ FortiGate B
 ```text
 config system auto-scale
     set status enable
+    set role secondary
     set sync-interface "port2"
-    set master-ip 172.16.136.69
+    set primary-ip 172.16.136.69
     set psksecret "a big secret"
 end
 ```

--- a/FortiGate/Active-Passive-ELB-ILB/README.md
+++ b/FortiGate/Active-Passive-ELB-ILB/README.md
@@ -77,9 +77,9 @@ The ARM template deploys different resources and it is required to have the acce
   - It needs to contain characters from at least 3 of the following groups: uppercase characters, lowercase characters, numbers, and special characters excluding '\' or '-'
 - The terms for the FortiGate PAYG or BYOL image in the Azure Marketplace needs to be accepted once before usage. This is done automatically during deployment via the Azure Portal. For the Azure CLI the commands below need to be run before the first deployment in a subscription.
   - BYOL
-`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm`
+`az vm image terms accept --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm`
   - PAYG
-`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm_payg_20190624`
+`az vm image terms accept --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm_payg_2022`
 
 ## FortiGate configuration
 

--- a/FortiGate/Active-Passive-SDN/README.md
+++ b/FortiGate/Active-Passive-SDN/README.md
@@ -74,9 +74,9 @@ The ARM template deploys different resources and it is required to have the acce
   - It needs to contain characters from at least 3 of the following groups: uppercase characters, lowercase characters, numbers, and special characters excluding '\' or '-'
 - The terms for the FortiGate PAYG or BYOL image in the Azure Marketplace needs to be accepted once before usage. This is done automatically during deployment via the Azure Portal. For the Azure CLI the commands below need to be run before the first deployment in a subscription.
   - BYOL
-`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm`
+`az vm image terms accept --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm`
   - PAYG
-`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm_payg_20190624`
+`az vm image terms accept --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm_payg_2022`
 
 ## FortiGate configuration
 

--- a/FortiGate/AzureChina/Active-Passive-ELB-ILB/README.md
+++ b/FortiGate/AzureChina/Active-Passive-ELB-ILB/README.md
@@ -74,9 +74,9 @@ The ARM template deploys different resources and it is required to have the acce
   - It needs to contain characters from at least 3 of the following groups: uppercase characters, lowercase characters, numbers, and special characters excluding '\' or '-'
 - The terms for the FortiGate PAYG or BYOL image in the Azure Marketplace needs to be accepted once before usage. This is done automatically during deployment via the Azure Portal. For the Azure CLI the commands below need to be run before the first deployment in a subscription.
   - BYOL
-`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm`
+`az vm image terms accept --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm`
   - PAYG
-`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm_payg_20190624`
+`az vm image terms accept --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm_payg_2022`
 
 ## FortiGate configuration
 

--- a/FortiGate/AzureRouteServer/Active-Passive/README.md
+++ b/FortiGate/AzureRouteServer/Active-Passive/README.md
@@ -58,10 +58,9 @@ The ARM template deploy different resource and it is required to have the access
   - It must be 12 characters or longer
   - It needs to contain characters from at least 3 of the following groups: uppercase characters, lowercase characters, numbers, and special characters excluding '\' or '-'
 - The terms for the FortiGate PAYG or BYOL image in the Azure Marketplace needs to be accepted once before usage. This is done automatically during deployment via the Azure Portal. For the Azure CLI the commands below need to be run before the first deployment in a subscription.
-  - BYOL
-`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm`
+`az vm image terms accept --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm`
   - PAYG
-`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm_payg_20190624`
+`az vm image terms accept --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm_payg_2022`
 
 ## Fabric Connector
 

--- a/FortiGate/AzureRouteServer/MultiHub/README.md
+++ b/FortiGate/AzureRouteServer/MultiHub/README.md
@@ -69,9 +69,9 @@ The ARM template deploy different resource and it is required to have the access
   - It needs to contain characters from at least 3 of the following groups: uppercase characters, lowercase characters, numbers, and special characters excluding '\' or '-'
 - The terms for the FortiGate PAYG or BYOL image in the Azure Marketplace needs to be accepted once before usage. This is done automatically during deployment via the Azure Portal. For the Azure CLI the commands below need to be run before the first deployment in a subscription.
   - BYOL
-`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm`
+`az vm image terms accept --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm`
   - PAYG
-`az vm image accept-terms --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm_payg_20190624`
+`az vm image terms accept --publisher fortinet --offer fortinet_fortigate-vm_v5 --plan fortinet_fg-vm_payg_2022`
 
 ## Fabric Connector
 

--- a/FortiGate/Playground/Active-Active-Internal-1NIC/README.md
+++ b/FortiGate/Playground/Active-Active-Internal-1NIC/README.md
@@ -94,35 +94,43 @@ config system cluster-sync
     next
 end
 ```
-* Where x in 10.0.1.x is the IP of port 1 of the opposite FortiGate. With the default values this would be either 5 or 6.
+
+- Where x in 10.0.1.x is the IP of port 1 of the opposite FortiGate. With the default values this would be either 5 or 6.
 
 ### Configuration synchronization
+
 The FortiGate VMs are in this Active/Active setup independent units. They don't use FGCP as a protocol to sync the configuration like in the Active/Passive setup. To enable configuration sync between both unit the sync from the autoscaling setup can be used. This will sync all configuration except for the specific configuration item proper to the specific VM like hostname, routing and others. To enable the configuration sync the config below can be used on both
 
 FortiGate A
-```
+
+```text
 config system auto-scale
     set status enable
-    set role master
+    set role primary
     set sync-interface "port2"
     set psksecret "a big secret"
 end
 ```
 
 FortiGate B
-```
+
+```text
 config system auto-scale
     set status enable
+    set role secondary
     set sync-interface "port2"
-    set master-ip 172.16.136.69
+    set primary-ip 172.16.136.69
     set psksecret "a big secret"
 end
 ```
 
+
 ## Support
+
 Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services.
 For direct issues, please refer to the [Issues](https://github.com/fortinet/azure-templates/issues) tab of this GitHub project.
 For other questions related to this project, contact [github@fortinet.com](mailto:github@fortinet.com).
 
 ## License
+
 [License](LICENSE) © Fortinet Technologies. All rights reserved.

--- a/FortiGate/Terraform/Active-Active-ELB-ILB/README.md
+++ b/FortiGate/Terraform/Active-Active-ELB-ILB/README.md
@@ -65,7 +65,7 @@ Often S-NAT is not desired because it's necessary to retain the original source 
 
 If you do prefer to use FGSP for session synchronization. It can be enable during deployment by uncommenting the section in the customdata.tpl file or adding this recommended configuration to both FortiGate VMs.
 
-```
+```text
 config system ha
     set session-pickup enable
     set session-pickup-connectionless enable
@@ -81,35 +81,42 @@ config system cluster-sync
     next
 end
 ```
-* Where x in 172.16.136.x is the IP of port 1 of the opposite FortiGate. With the default values this would be either 5 or 6.
+
+- Where x in 172.16.136.x is the IP of port 1 of the opposite FortiGate. With the default values this would be either 5 or 6.
 
 ### Configuration synchronization
+
 The FortiGate VMs are in this Active/Active setup independent units. They don't use FGCP as a protocol to sync the configuration like in the Active/Passive setup. To enable configuration sync between both unit the sync from the autoscaling setup can be used. This will sync all configuration except for the specific configuration item proper to the specific VM like hostname, routing and others. To enable the configuration sync the config below can be used on both
 
 FortiGate A
-```
+
+```text
 config system auto-scale
     set status enable
-    set role master
+    set role primary
     set sync-interface "port2"
     set psksecret "a big secret"
 end
 ```
 
 FortiGate B
-```
+
+```text
 config system auto-scale
     set status enable
+    set role secondary
     set sync-interface "port2"
-    set master-ip 172.16.136.69
+    set primary-ip 172.16.136.69
     set psksecret "a big secret"
 end
 ```
 
 ## Support
+
 Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services.
 For direct issues, please refer to the [Issues](https://github.com/fortinet/azure-templates/issues) tab of this GitHub project.
 For other questions related to this project, contact [github@fortinet.com](mailto:github@fortinet.com).
 
 ## License
+
 [License](LICENSE) © Fortinet Technologies. All rights reserved.


### PR DESCRIPTION
A few changes to README.md

- Update existing az CLI command for `az vm image accept-terms` to change deprecated `accept-terms` to `terms accept`
- Update existing az CLI command for `az vm image accept-terms` to change sku`fortinet_fg-vm_payg_20190624` to `fortinet_fg-vm_payg_2022`
- Update A/A configs to use `primary` and `primary-ip` instead of `master` and `master-ip`
- Update A/A configs to use `set role secondary`

