### PR TITLE
Add FortiPAM A-Single-VM building block

### DIFF
--- a/.github/workflows/fpam-arm-a-single-vm.yml
+++ b/.github/workflows/fpam-arm-a-single-vm.yml
@@ -1,0 +1,135 @@
+name: '[FPAM] ARM - A-Single-VM'
+
+env:
+  ARMPath: FortiPAM/A-Single-VM/
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'FortiPAM/A-Single-VM/*.json'
+      - 'FortiPAM/A-Single-VM/test/*.ps1'
+
+jobs:
+
+  # ── Job 1: ARM Template Toolkit validation (no Azure credentials needed) ────
+  ttk:
+    name: 'ARM TTK Validation'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+
+    - name: Get week (ARM TTK cache key)
+      id: week
+      run: echo "value=$(date +'%Y-%U')" >> $GITHUB_OUTPUT
+
+    - name: Cache ARM TTK
+      id: cache-armttk
+      uses: actions/cache@v5
+      with:
+        path: arm-ttk
+        key: arm-ttk-${{ steps.week.outputs.value }}
+
+    - name: Cache Pester 4.10.1
+      id: cache-pester4
+      uses: actions/cache@v5
+      with:
+        path: ~/.local/share/powershell/Modules/Pester/4.10.1
+        key: pester-4.10.1
+
+    - name: Download and extract ARM TTK
+      if: steps.cache-armttk.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        Invoke-WebRequest -Uri "https://aka.ms/arm-ttk-latest" -OutFile arm-template-toolkit.zip
+        Expand-Archive -LiteralPath arm-template-toolkit.zip -DestinationPath arm-ttk
+
+    - name: Install Pester 4.10.1
+      if: steps.cache-pester4.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        Install-Module -Name Pester -RequiredVersion 4.10.1 -Force -Scope CurrentUser
+
+    - name: Validate ARM templates with ARM TTK
+      shell: pwsh
+      run: |
+        Import-Module -Name Pester -RequiredVersion 4.10.1 -Force
+        Import-Module ./arm-ttk/arm-ttk/arm-ttk.psd1
+        "Test-AzTemplate -TemplatePath ${{ env.ARMPath }} -Pester" | Out-File -FilePath ./armttk.ps1
+        Invoke-Pester -Script ./armttk.ps1 -EnableExit -OutputFormat NUnitXml -OutputFile ./test-armttk.xml
+
+    - name: Publish TTK results
+      uses: actions/upload-artifact@v6
+      with:
+        name: FPAM-A-Single-VM-TTK-Results
+        path: ./test-armttk.xml
+      if: always()
+
+  # ── Job 2: Deploy and test ───────────────────────────────────────────────────
+  deploy:
+    name: 'Deploy and Test'
+    runs-on: ubuntu-latest
+    needs: ttk                 # skip costly deployments if template is structurally broken
+    permissions:
+      contents: read
+      id-token: write          # required for OIDC authentication with Azure
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+
+    - name: Azure Login
+      uses: azure/login@v3
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        enable-AzPSSession: true
+
+    - name: Run Pester tests
+      shell: pwsh
+      run: |
+        if (-not (Get-Module -ListAvailable -Name Pester | Where-Object { $_.Version -ge [version]'5.7.1' })) {
+            Set-PSRepository psgallery -InstallationPolicy trusted
+            Install-Module -Name Pester -MinimumVersion 5.7.1 -Confirm:$false -Force -SkipPublisherCheck
+        }
+        Import-Module Pester -MinimumVersion 5.7.1 -Force
+        $container = New-PesterContainer -Path "${{ env.ARMPath }}test/"
+        $config = New-PesterConfiguration
+        $config.Run.Container           = $container
+        $config.Run.Exit                = $true
+        $config.Run.PassThru            = $true
+        $config.TestResult.Enabled      = $true
+        $config.TestResult.OutputFormat = "NUnitXML"
+        $config.TestResult.OutputPath   = "test-custom.xml"
+        $config.Output.Verbosity        = 'Detailed'
+        Invoke-Pester -Configuration $config
+
+    - name: Publish test results
+      uses: actions/upload-artifact@v6
+      with:
+        name: FPAM-A-Single-VM-Test-Results
+        path: ./test-custom.xml
+      if: always()
+
+  # ── Job 3: Teams notification after all jobs complete ───────────────────────
+  notify:
+    name: 'Teams Notification'
+    runs-on: ubuntu-latest
+    needs: [ttk, deploy]
+    if: always()
+
+    steps:
+    - name: Microsoft Teams Notification
+      uses: skitionek/notify-microsoft-teams@v1
+      with:
+        webhook_url: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+        needs: ${{ toJson(needs) }}
+        job: ${{ toJson(job) }}
+        steps: ${{ toJson(steps) }}

--- a/FortiPAM/A-Single-VM/README.md
+++ b/FortiPAM/A-Single-VM/README.md
@@ -1,74 +1,72 @@
-# FortiAnalyzer
+# FortiPAM
 
 ## Introduction
 
-FortiAnalyzer - Analytics driven security management
+FortiPAM - Privileged Access Management
 
-FortiAnalyzer offers centralized network security logging and reporting for the Fortinet Security Fabric. FortiAnalyzer accepts inbound logs from multiple downstream Fortinet devices such as FortiGate, FortiMail, and FortiWeb devices etc.
-
-This ARM template deploys a single FortiAnalyzer accompanied by the required infrastructure.
+FortiPAM provides role-based access, auditing, and security options for privileged users. This ARM template deploys a single FortiPAM-VM accompanied by the required infrastructure.
 
 ## Design
 
-In Microsoft Azure, this single FortiAnalyzer-VM setup a basic setup to start exploring the capabilities of the analytics platform for the different Fortinet solutions.
+This Azure ARM template deploys a single FortiPAM-VM in a basic standalone setup to start exploring the capabilities of the FortiPAM privileged access management platform.
 
-This Azure ARM template will automatically deploy a full working environment containing the following components.
+This Azure ARM template automatically deploys a full working environment containing the following components:
 
-- 1 FortiAnalyzer VM with a 1Tb data disk for log storage
-- 1 VNETs containing a subnet for the FortiAnalyzer
-- Optional: 1 Basic public IP
+- 1 FortiPAM VM with two data disks (one for logs, one for video recordings). Minimum 10 GB each; the recommended log:video disk ratio is 1:3.
+- 1 VNET containing a subnet for the FortiPAM VM
+- Optional: 1 Standard public IP
 
-<p align="center">
-  <img src="images/faz-single-small.png" alt="FortiAnalyzer-VM azure design"/>
-</p>
+This Azure ARM template can be extended or customized based on your requirements. Additional subnets are not automatically generated.
 
-This Azure ARM template can also be extended or customized based on your requirements. Additional subnets besides the ones mentioned above are not automatically generated.
-
-The FortiAnalyzer can also be deployed without a public IP on the network interface. Select 'None' as the public IP.
-
-<p align="center">
-  <img src="images/faz-single-private-small.png" alt="FortiAnalyzer-VM azure design"/>
-</p>
+The FortiPAM VM can also be deployed without a public IP on the network interface. Select 'None' as the public IP.
 
 ## Deployment
 
-For the deployment, you can use the Azure Portal, Azure CLI, Powershell or Azure Cloud Shell. The Azure ARM templates are exclusive to Microsoft Azure and can't be used in other cloud environments. The main template is the `mainTemplate.json` which you can use in the Azure Portal. A `deploy.sh` script is provided to facilitate the deployment. You'll be prompted to provide the 4 required variables:
+For the deployment, you can use the Azure Portal, Azure CLI, PowerShell or Azure Cloud Shell. The Azure ARM templates are exclusive to Microsoft Azure. The main template is `mainTemplate.json`. A `deploy.sh` script is provided to facilitate the deployment. You will be prompted for the 4 required variables:
 
-- PREFIX : This prefix will be added to each of the resources created by the template for ease of use and visibility.
-- LOCATION : This is the Azure region where the deployment will be deployed.
-- USERNAME : The username used to login to the FortiAnalyzer GUI and SSH management UI.
-- PASSWORD : The password used for the FortiAnalyze GUI and SSH management UI.
+- PREFIX : added to each resource created by the template.
+- LOCATION : the Azure region for the deployment.
+- USERNAME : the username used to login to the FortiPAM GUI and SSH CLI.
+- PASSWORD : the password used for the FortiPAM GUI and SSH CLI.
+
+**Marketplace terms:** the FortiPAM marketplace image (`fortinet:fortinet-fortipam:fortinet-fpam`) requires terms acceptance. The `deploy.sh` script runs `az vm image terms accept` automatically before deploying.
+
+**Licensing:** FortiPAM uses a BYOL (yearly user subscription) model. The license file (`.lic`) is uploaded **after deployment via SCP or the GUI** -- it is NOT injected during deployment. "Evaluation license is not available on Azure." Each FortiPAM instance must have its own valid license.
 
 ### Azure Portal
 
 Azure Portal Wizard:
-[![Azure Portal Wizard](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2F40net-cloud%2Ffortinet-azure-solutions%2Fmain%2FFortiAnalyzer%2Fsingle%2FmainTemplate.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2F40net-cloud%2Ffortinet-azure-solutions%2Fmain%2FFortiAnalyzer%2Fsingle%2FcreateUiDefinition.json)
+[![Azure Portal Wizard](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2F40net-cloud%2Ffortinet-azure-solutions%2Fmain%2FFortiPAM%2FA-Single-VM%2FmainTemplate.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2F40net-cloud%2Ffortinet-azure-solutions%2Fmain%2FFortiPAM%2FA-Single-VM%2FcreateUiDefinition.json)
 
 Custom deployment:
-[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2F40net-cloud%2Ffortinet-azure-solutions%2Fmain%2FFortiAnalyzer%2Fsingle%2FmainTemplate.json)
-[![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Ffortinet%2Fazure-templates$2Fmain%2FFortiAnalyzer%2Fsingle%2FmainTemplate.json)
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2F40net-cloud%2Ffortinet-azure-solutions%2Fmain%2FFortiPAM%2FA-Single-VM%2FmainTemplate.json)
 
 ### Azure CLI
-To fast track the deployment, use the Azure Cloud Shell. The Azure Cloud Shell is an in-browser CLI that contains Terraform and other tools for deployment into Microsoft Azure. It is accessible via the Azure Portal or directly at [https://shell.azure.com/](https://shell.azure.com). You can copy and paste the below one-liner to get started with your deployment.
 
-`cd ~/clouddrive/ && wget -qO- https://github.com/fortinet/azure-templates/archive/main.tar.gz | tar zxf - && cd ~/clouddrive/azure-templates-main/FortiAnalyzer/single/ && ./deploy.sh`
+Use the Azure Cloud Shell ([https://shell.azure.com/](https://shell.azure.com)):
 
-![Azure Cloud Shell](images/azure-cloud-shell.png)
+`cd ~/clouddrive/ && wget -qO- https://github.com/40net-cloud/fortinet-azure-solutions/archive/main.tar.gz | tar zxf - && cd ~/clouddrive/fortinet-azure-solutions-main/FortiPAM/A-Single-VM/ && ./deploy.sh`
 
-After deployment, you will be shown the IP addresses of all deployed components. This information is also stored in the output directory in the 'summary.out' file. You can access both management GUI's using the public management IP addresses using HTTPS on port 443.
+After deployment you can access the FortiPAM GUI over HTTPS on port 443 using the public IP, and the CLI over SSH on port 22.
 
 ## Requirements and limitations
 
-The Azure ARM template deployment deploys different resources and is required to have the access rights and quota in your Microsoft Azure subscription to deploy the resources.
+- The default VM size is `Standard_D4s_v5` (4 vCPU / 16 GB). FortiPAM sizing: 4-64 vCPU, 16-256 GB RAM for 20-1000 users. The FortiPAM image is x64 only.
+- A Network Security Group opens TCP 22 (SSH/CLI) and 443 (HTTPS GUI) inbound, and all outbound. Additional ports (e.g. 8443 reverse service, 4433 FortiToken Mobile) are documented in the [FortiPAM ports reference](https://docs.fortinet.com/document/fortipam/1.9.0/fortipam-ports).
+- License for FortiPAM: BYOL, uploaded post-deploy via SCP or GUI.
 
-- The template will deploy Standard D3s VMs for this architecture. Other VM instances are supported as well with a recommended minimum of 2 vCPU and 4Gb of RAM. A list can be found [here](https://docs.fortinet.com/document/fortianalyzer-public-cloud/7.2.0/azure-administration-guide/351055)
-- A Network Security Group is installed that only opens TCP port 22, 443 and 514 for access to the FortiAnalyzer. Additional ports might be needed to support your use case and are documented [here](https://docs.fortinet.com/document/fortianalyzer/7.2.0/fortianalyzer-ports/290737)
-- License for FortiAnalyzer
-  - BYOL: A demo license can be made available via your Fortinet partner or on our website. These can be injected during deployment or added after deployment.
+## TODO (attribution GUIDs -- non-blocking placeholders)
+
+Two attribution identifiers are placeholders pending confirmation:
+
+- `fortinetTags.provider` in `mainTemplate.json` + `mainTemplate.parameters.json`: currently `6EB3B02F-50E5-4A3E-8CB8-2E1292583TODO` (pending the real FortiPAM provider suffix from the repo maintainer).
+- Partner Center PID resource name in `mainTemplate.json`: currently `pid-00000000-0000-0000-0000-000000000000-partnercenter` (pending the real CUA tracking GUID from Partner Center).
+
+Both are attribution-only and do not affect deployment.
 
 ## Support
-Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services.
-For direct issues, please refer to the [Issues](https://github.com/fortinet/azure-templates/issues) tab of this GitHub project.
+
+Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services. For direct issues, please refer to the [Issues](https://github.com/40net-cloud/fortinet-azure-solutions/issues) tab of this GitHub project.
 
 ## License
-[License](/../../blob/main/LICENSE) © Fortinet Technologies. All rights reserved.
+[License](/../../blob/main/LICENSE) (c) Fortinet Technologies. All rights reserved.

--- a/FortiPAM/A-Single-VM/README.md
+++ b/FortiPAM/A-Single-VM/README.md
@@ -1,0 +1,74 @@
+# FortiAnalyzer
+
+## Introduction
+
+FortiAnalyzer - Analytics driven security management
+
+FortiAnalyzer offers centralized network security logging and reporting for the Fortinet Security Fabric. FortiAnalyzer accepts inbound logs from multiple downstream Fortinet devices such as FortiGate, FortiMail, and FortiWeb devices etc.
+
+This ARM template deploys a single FortiAnalyzer accompanied by the required infrastructure.
+
+## Design
+
+In Microsoft Azure, this single FortiAnalyzer-VM setup a basic setup to start exploring the capabilities of the analytics platform for the different Fortinet solutions.
+
+This Azure ARM template will automatically deploy a full working environment containing the following components.
+
+- 1 FortiAnalyzer VM with a 1Tb data disk for log storage
+- 1 VNETs containing a subnet for the FortiAnalyzer
+- Optional: 1 Basic public IP
+
+<p align="center">
+  <img src="images/faz-single-small.png" alt="FortiAnalyzer-VM azure design"/>
+</p>
+
+This Azure ARM template can also be extended or customized based on your requirements. Additional subnets besides the ones mentioned above are not automatically generated.
+
+The FortiAnalyzer can also be deployed without a public IP on the network interface. Select 'None' as the public IP.
+
+<p align="center">
+  <img src="images/faz-single-private-small.png" alt="FortiAnalyzer-VM azure design"/>
+</p>
+
+## Deployment
+
+For the deployment, you can use the Azure Portal, Azure CLI, Powershell or Azure Cloud Shell. The Azure ARM templates are exclusive to Microsoft Azure and can't be used in other cloud environments. The main template is the `mainTemplate.json` which you can use in the Azure Portal. A `deploy.sh` script is provided to facilitate the deployment. You'll be prompted to provide the 4 required variables:
+
+- PREFIX : This prefix will be added to each of the resources created by the template for ease of use and visibility.
+- LOCATION : This is the Azure region where the deployment will be deployed.
+- USERNAME : The username used to login to the FortiAnalyzer GUI and SSH management UI.
+- PASSWORD : The password used for the FortiAnalyze GUI and SSH management UI.
+
+### Azure Portal
+
+Azure Portal Wizard:
+[![Azure Portal Wizard](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2F40net-cloud%2Ffortinet-azure-solutions%2Fmain%2FFortiAnalyzer%2Fsingle%2FmainTemplate.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2F40net-cloud%2Ffortinet-azure-solutions%2Fmain%2FFortiAnalyzer%2Fsingle%2FcreateUiDefinition.json)
+
+Custom deployment:
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2F40net-cloud%2Ffortinet-azure-solutions%2Fmain%2FFortiAnalyzer%2Fsingle%2FmainTemplate.json)
+[![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Ffortinet%2Fazure-templates$2Fmain%2FFortiAnalyzer%2Fsingle%2FmainTemplate.json)
+
+### Azure CLI
+To fast track the deployment, use the Azure Cloud Shell. The Azure Cloud Shell is an in-browser CLI that contains Terraform and other tools for deployment into Microsoft Azure. It is accessible via the Azure Portal or directly at [https://shell.azure.com/](https://shell.azure.com). You can copy and paste the below one-liner to get started with your deployment.
+
+`cd ~/clouddrive/ && wget -qO- https://github.com/fortinet/azure-templates/archive/main.tar.gz | tar zxf - && cd ~/clouddrive/azure-templates-main/FortiAnalyzer/single/ && ./deploy.sh`
+
+![Azure Cloud Shell](images/azure-cloud-shell.png)
+
+After deployment, you will be shown the IP addresses of all deployed components. This information is also stored in the output directory in the 'summary.out' file. You can access both management GUI's using the public management IP addresses using HTTPS on port 443.
+
+## Requirements and limitations
+
+The Azure ARM template deployment deploys different resources and is required to have the access rights and quota in your Microsoft Azure subscription to deploy the resources.
+
+- The template will deploy Standard D3s VMs for this architecture. Other VM instances are supported as well with a recommended minimum of 2 vCPU and 4Gb of RAM. A list can be found [here](https://docs.fortinet.com/document/fortianalyzer-public-cloud/7.2.0/azure-administration-guide/351055)
+- A Network Security Group is installed that only opens TCP port 22, 443 and 514 for access to the FortiAnalyzer. Additional ports might be needed to support your use case and are documented [here](https://docs.fortinet.com/document/fortianalyzer/7.2.0/fortianalyzer-ports/290737)
+- License for FortiAnalyzer
+  - BYOL: A demo license can be made available via your Fortinet partner or on our website. These can be injected during deployment or added after deployment.
+
+## Support
+Fortinet-provided scripts in this and other GitHub projects do not fall under the regular Fortinet technical support scope and are not supported by FortiCare Support Services.
+For direct issues, please refer to the [Issues](https://github.com/fortinet/azure-templates/issues) tab of this GitHub project.
+
+## License
+[License](/../../blob/main/LICENSE) © Fortinet Technologies. All rights reserved.

--- a/FortiPAM/A-Single-VM/createUiDefinition.json
+++ b/FortiPAM/A-Single-VM/createUiDefinition.json
@@ -17,9 +17,9 @@
       {
         "name": "adminUsername",
         "type": "Microsoft.Common.TextBox",
-        "label": "FortiAnalyzer administrative username",
+        "label": "FortiPAM administrative username",
         "defaultValue": "",
-        "toolTip": "Username for the FortiAnalyzer virtual appliance. Most not be root, administrator or admin",
+        "toolTip": "Username for the FortiPAM virtual appliance. Most not be root, administrator or admin",
         "constraints": {
           "required": true,
           "validations": [
@@ -43,7 +43,7 @@
         "name": "adminPassword",
         "type": "Microsoft.Common.PasswordBox",
         "label": {
-          "password": "FortiAnalyzer password",
+          "password": "FortiPAM password",
           "confirmPassword": "Confirm password"
         },
         "toolTip": "Password for the Virtual Machine",
@@ -60,7 +60,7 @@
       {
         "name": "namePrefix",
         "type": "Microsoft.Common.TextBox",
-        "label": "FortiAnalyzer Name Prefix",
+        "label": "FortiPAM Name Prefix",
         "defaultValue": "",
         "toolTip": "Naming prefix for all deployed resources",
         "constraints": {
@@ -73,15 +73,15 @@
       {
         "name": "imageSku",
         "type": "Microsoft.Common.DropDown",
-        "label": "FortiAnalyzer Image SKU",
-        "defaultValue": "Bring Your Own License",
+        "label": "FortiPAM Image SKU",
+        "defaultValue": "fortinet-fpam",
         "toolTip": "BYOL license model (where license is purchased separately)",
         "constraints": {
           "required": false,
           "allowedValues": [
             {
-              "label": "Bring Your Own License",
-              "value": "fortinet-fortianalyzer"
+              "label": "fortinet-fpam",
+              "value": "fortinet-fpam"
             }
           ]
         },
@@ -90,260 +90,17 @@
       {
         "name": "imageVersion",
         "type": "Microsoft.Common.DropDown",
-        "label": "FortiAnalyzer Image Version",
-        "defaultValue": "7.6.3",
-        "toolTip": "Only 6.x has the A/P HA feature currently",
+        "label": "FortiPAM Image Version",
+        "defaultValue": "1.9.0",
+        "toolTip": "FortiPAM image version (1.9.0 is newest)",
         "constraints": {
           "required": false,
           "allowedValues": [
-            {
-              "label": "latest",
-              "value": "latest"
-            },
-            {
-              "label": "7.6.6",
-              "value": "7.6.6"
-            },
-            {
-              "label": "7.6.5",
-              "value": "7.6.5"
-            },
-            {
-              "label": "7.6.4",
-              "value": "7.6.4"
-            },
-            {
-              "label": "7.6.3",
-              "value": "7.6.3"
-            },
-            {
-              "label": "7.6.2",
-              "value": "7.6.2"
-            },
-            {
-              "label": "7.6.1",
-              "value": "7.6.1"
-            },
-            {
-              "label": "7.6.0",
-              "value": "7.6.0"
-            },
-            {
-              "label": "7.4.8",
-              "value": "7.4.8"
-            },
-            {
-              "label": "7.4.7",
-              "value": "7.4.7"
-            },
-            {
-              "label": "7.4.6",
-              "value": "7.4.6"
-            },
-            {
-              "label": "7.4.5",
-              "value": "7.4.5"
-            },
-            {
-              "label": "7.4.4",
-              "value": "7.4.4"
-            },
-            {
-              "label": "7.4.3",
-              "value": "7.4.3"
-            },
-            {
-              "label": "7.4.2",
-              "value": "7.4.2"
-            },
-            {
-              "label": "7.4.1",
-              "value": "7.4.1"
-            },
-            {
-              "label": "7.4.0",
-              "value": "7.4.0"
-            },
-            {
-              "label": "7.2.9",
-              "value": "7.2.9"
-            },
-            {
-              "label": "7.2.8",
-              "value": "7.2.8"
-            },
-            {
-              "label": "7.2.7",
-              "value": "7.2.7"
-            },
-            {
-              "label": "7.2.6",
-              "value": "7.2.6"
-            },
-            {
-              "label": "7.2.5",
-              "value": "7.2.5"
-            },
-            {
-              "label": "7.2.4",
-              "value": "7.2.4"
-            },
-            {
-              "label": "7.2.3",
-              "value": "7.2.3"
-            },
-            {
-              "label": "7.2.2",
-              "value": "7.2.2"
-            },
-            {
-              "label": "7.2.11",
-              "value": "7.2.11"
-            },
-            {
-              "label": "7.2.10",
-              "value": "7.2.10"
-            },
-            {
-              "label": "7.2.1",
-              "value": "7.2.1"
-            },
-            {
-              "label": "7.2.0",
-              "value": "7.2.0"
-            },
-            {
-              "label": "7.0.9",
-              "value": "7.0.9"
-            },
-            {
-              "label": "7.0.7",
-              "value": "7.0.7"
-            },
-            {
-              "label": "7.0.6",
-              "value": "7.0.6"
-            },
-            {
-              "label": "7.0.5",
-              "value": "7.0.5"
-            },
-            {
-              "label": "7.0.4",
-              "value": "7.0.4"
-            },
-            {
-              "label": "7.0.3",
-              "value": "7.0.3"
-            },
-            {
-              "label": "7.0.2",
-              "value": "7.0.2"
-            },
-            {
-              "label": "7.0.14",
-              "value": "7.0.14"
-            },
-            {
-              "label": "7.0.13",
-              "value": "7.0.13"
-            },
-            {
-              "label": "7.0.12",
-              "value": "7.0.12"
-            },
-            {
-              "label": "7.0.11",
-              "value": "7.0.11"
-            },
-            {
-              "label": "7.0.10",
-              "value": "7.0.10"
-            },
-            {
-              "label": "7.0.1",
-              "value": "7.0.1"
-            },
-            {
-              "label": "7.0.0",
-              "value": "7.0.0"
-            },
-            {
-              "label": "6.4.9",
-              "value": "6.4.9"
-            },
-            {
-              "label": "6.4.8",
-              "value": "6.4.8"
-            },
-            {
-              "label": "6.4.7",
-              "value": "6.4.7"
-            },
-            {
-              "label": "6.4.6",
-              "value": "6.4.6"
-            },
-            {
-              "label": "6.4.5",
-              "value": "6.4.5"
-            },
-            {
-              "label": "6.4.2",
-              "value": "6.4.2"
-            },
-            {
-              "label": "6.4.15",
-              "value": "6.4.15"
-            },
-            {
-              "label": "6.4.14",
-              "value": "6.4.14"
-            },
-            {
-              "label": "6.4.13",
-              "value": "6.4.13"
-            },
-            {
-              "label": "6.4.12",
-              "value": "6.4.12"
-            },
-            {
-              "label": "6.4.11",
-              "value": "6.4.11"
-            },
-            {
-              "label": "6.4.10",
-              "value": "6.4.10"
-            },
-            {
-              "label": "6.4.1",
-              "value": "6.4.1"
-            },
-            {
-              "label": "6.4.0",
-              "value": "6.4.0"
-            },
-            {
-              "label": "6.2.5",
-              "value": "6.2.5"
-            },
-            {
-              "label": "6.2.3",
-              "value": "6.2.3"
-            },
-            {
-              "label": "6.2.2",
-              "value": "6.2.2"
-            },
-            {
-              "label": "6.2.1",
-              "value": "6.2.1"
-            },
-            {
-              "label": "6.2.0",
-              "value": "6.2.0"
-            }
+            { "label": "latest", "value": "latest" },
+            { "label": "1.9.0", "value": "1.9.0" },
+            { "label": "1.7.0", "value": "1.7.0" },
+            { "label": "1.3.0", "value": "1.3.0" },
+            { "label": "1.1.2", "value": "1.1.2" }
           ]
         },
         "visible": true
@@ -368,10 +125,10 @@
                 "type": "Microsoft.Common.TextBlock",
                 "visible": true,
                 "options": {
-                  "text": "For this FortiAnalyzer deployment, it is recommended to use general purpose virtual machines. A selection of supported instances sizes is listed in our documentation.",
+                  "text": "For this FortiPAM deployment, it is recommended to use general purpose virtual machines. A selection of supported instances sizes is listed in our documentation.",
                   "link": {
                     "label": "Learn more",
-                    "uri": "https://docs.fortinet.com/document/fortianalyzer-public-cloud/7.2.0/azure-administration-guide/351055"
+                    "uri": "https://docs.fortinet.com/document/fortipam-public-cloud/1.9.0/azure-administration-guide"
                   }
                 }
               },
@@ -379,27 +136,13 @@
                 "name": "instancetypeselection",
                 "type": "Microsoft.Compute.SizeSelector",
                 "label": "Size",
-                "toolTip": "Select the instance size of your FortiAnalyzer VM solution. Minimum 4 NICs are required.",
+                "toolTip": "Select the instance size of your FortiPAM VM solution. Minimum 4 NICs are required.",
                 "recommendedSizes": [
                   "Standard_DS4_v2",
                   "Standard_DS5_v2",
                   "Standard_D4_v3",
                   "Standard_D8_v3",
                   "Standard_D16_v3",
-                  "Standard_D4a_v4",
-                  "Standard_D8a_v4",
-                  "Standard_D16a_v4",
-                  "Standard_D32a_v4",
-                  "Standard_D48a_v4",
-                  "Standard_D64a_v4",
-                  "Standard_D96a_v4",
-                  "Standard_D4as_v4",
-                  "Standard_D8as_v4",
-                  "Standard_D16as_v4",
-                  "Standard_D32as_v4",
-                  "Standard_D48as_v4",
-                  "Standard_D64as_v4",
-                  "Standard_D96as_v4",
                   "Standard_D4_v5",
                   "Standard_D8_v5",
                   "Standard_D16_v5",
@@ -422,20 +165,6 @@
                     "Standard_D4_v3",
                     "Standard_D8_v3",
                     "Standard_D16_v3",
-                    "Standard_D4a_v4",
-                    "Standard_D8a_v4",
-                    "Standard_D16a_v4",
-                    "Standard_D32a_v4",
-                    "Standard_D48a_v4",
-                    "Standard_D64a_v4",
-                    "Standard_D96a_v4",
-                    "Standard_D4as_v4",
-                    "Standard_D8as_v4",
-                    "Standard_D16as_v4",
-                    "Standard_D32as_v4",
-                    "Standard_D48as_v4",
-                    "Standard_D64as_v4",
-                    "Standard_D96as_v4",
                     "Standard_D4_v5",
                     "Standard_D8_v5",
                     "Standard_D16_v5",
@@ -458,8 +187,8 @@
                 "osPlatform": "Linux",
                 "imageReference": {
                   "publisher": "fortinet",
-                  "offer": "fortinet-fortianalyzer",
-                  "sku": "fortinet-fortianalyzer"
+                  "offer": "fortinet-fortipam",
+                  "sku": "fortinet-fpam"
                 },
                 "count": 1,
                 "visible": true
@@ -475,8 +204,8 @@
                 "name": "vmDataDiskCount",
                 "type": "Microsoft.Common.TextBox",
                 "label": "Number of managed disks per data node",
-                "defaultValue": "1",
-                "toolTip": "Number of disks to attach to the FortiAnalyzer.",
+                "defaultValue": "2",
+                "toolTip": "Number of disks to attach to the FortiPAM.",
                 "constraints": {
                   "required": true,
                   "regex": "^([0-9]|1[0-5])$",
@@ -488,8 +217,8 @@
                 "type": "Microsoft.Common.DropDown",
                 "label": "Size of each managed disk",
                 "visible": "[greater(steps('instance').datadisk.vmDataDiskCount, 0)]",
-                "defaultValue": "1TiB",
-                "toolTip": "The size of each data disk to attach to the FortiAnalyzer",
+                "defaultValue": "128GiB",
+                "toolTip": "The size of each data disk to attach to the FortiPAM",
                 "constraints": {
                   "allowedValues": [
                     {
@@ -587,10 +316,10 @@
                 "type": "Microsoft.Common.TextBlock",
                 "visible": true,
                 "options": {
-                  "text": "Deploy FortiAnalyzer VMs in an availability set or availability zone.",
+                  "text": "Deploy FortiPAM VMs in an availability set or availability zone.",
                   "link": {
                     "label": "Learn more",
-                    "uri": "https://github.com/fortinet/azure-templates/tree/main/FortiGate#sla"
+                    "uri": "https://github.com/40net-cloud/fortinet-azure-solutions"
                   }
                 }
               },
@@ -599,7 +328,7 @@
                 "type": "Microsoft.Common.DropDown",
                 "label": "Availability Option",
                 "defaultValue": "No infrastructure redundancy required",
-                "toolTip": "Deploy FortiAnalyzer VMs in a new or existing availability set or or a specific availability zone.",
+                "toolTip": "Deploy FortiPAM VMs in a new or existing availability set or or a specific availability zone.",
                 "constraints": {
                   "required": false,
                   "allowedValues": [
@@ -623,14 +352,14 @@
                 "name": "availabilitySetNew",
                 "type": "Microsoft.Common.CheckBox",
                 "label": "Create a new availability set?",
-                "toolTip": "Check this box if you want to create a new availability set and add the FortiAnalyzer VM to it.",
+                "toolTip": "Check this box if you want to create a new availability set and add the FortiPAM VM to it.",
                 "visible": "[equals(steps('instance').availabilityOptions.availabilityOptions,'Availability set')]"
               },
               {
                 "name": "availabilitySetSelector",
                 "type": "Microsoft.Solutions.ResourceSelector",
-                "label": "Select the availability set for your FortiAnalyzer",
-                "toolTip": "Select your existing availability set you want to add this FortiAnalyzer VM to",
+                "label": "Select the availability set for your FortiPAM",
+                "toolTip": "Select your existing availability set you want to add this FortiPAM VM to",
                 "resourceType": "Microsoft.Compute/availabilitySets",
                 "options": {
                   "filter": {
@@ -645,15 +374,15 @@
                 "type": "Microsoft.Common.InfoBox",
                 "options": {
                   "icon": "Info",
-                  "text": "The FortiAnalyzer VM and availability set are required to exist in the same resource group."
+                  "text": "The FortiPAM VM and availability set are required to exist in the same resource group."
                 },
                 "visible": "[and(not(steps('instance').availabilityOptions.availabilitySetNew),equals(steps('instance').availabilityOptions.availabilityOptions,'Availability set'))]"
               },
               {
                 "name": "availabilityZoneSelector",
                 "type": "Microsoft.Common.DropDown",
-                "label": "Select the availability zone for your FortiAnalyzer VM",
-                "toolTip": "Select the availability zone for your FortiAnalyzer VM",
+                "label": "Select the availability zone for your FortiPAM VM",
+                "toolTip": "Select the availability zone for your FortiPAM VM",
                 "defaultValue": "Zone 2",
                 "constraints": {
                   "allowedValues": [
@@ -679,61 +408,9 @@
                 "visible": true,
                 "options": {
                   "icon": "Info",
-                  "text": "If availability zone deployment is selected but the location does not support availability zone an availability set will be deployed. If availability zone deployment is selected and availability zone are available in the location, FortiAnalyzer A will be placed in Zone 1, FortiAnalyzer B will be placed in Zone 2",
+                  "text": "If availability zone deployment is selected but the location does not support availability zone an availability set will be deployed. If availability zone deployment is selected and availability zone are available in the location, FortiPAM A will be placed in Zone 1, FortiPAM B will be placed in Zone 2",
                   "uri": "https://docs.microsoft.com/en-us/azure/availability-zones/az-overview"
                 }
-              }
-            ]
-          },
-          {
-            "name": "fazLicense",
-            "type": "Microsoft.Common.Section",
-            "label": "FortiAnalyzer License",
-            "elements": [
-              {
-                "name": "fazLicenseBYOLInfo",
-                "type": "Microsoft.Common.TextBlock",
-                "visible": true,
-                "options": {
-                  "text": "The Bring Your Own license file(s), retrieved from support.fortinet.com, can be uploaded here or uploaded after deployment."
-                }
-              },
-              {
-                "name": "fazLicenseFortiFlexCheck",
-                "type": "Microsoft.Common.CheckBox",
-                "label": "My organisation is using the FortiFlex subscription service.",
-                "toolTip": "Select this box to enter a FortiFlex token",
-                "visible": true
-              },
-              {
-                "name": "fazcontent",
-                "type": "Microsoft.Common.FileUpload",
-                "label": "FortiAnalyzer License",
-                "toolTip": "Upload the license file for the FortiAnalyzer BYOL here.",
-                "constraints": {
-                  "required": false,
-                  "accept": ".lic,.txt"
-                },
-                "options": {
-                  "multiple": false,
-                  "uploadMode": "file",
-                  "openMode": "text",
-                  "encoding": "UTF-8"
-                },
-                "visible": "[not(steps('instance').fazLicense.fazLicenseFortiFlexCheck)]"
-              },
-              {
-                "name": "fazfortiflex",
-                "type": "Microsoft.Common.TextBox",
-                "label": "FortiAnalyzer FortiFlex",
-                "defaultValue": "",
-                "toolTip": "FortiAnalyzer FortiFlex license token",
-                "constraints": {
-                  "required": false,
-                  "regex": "^[A-Za-z0-9-]{1,64}$",
-                  "validationMessage": "Only alphanumeric characters and a dash are allowed, and the value must be 1 to 64 characters."
-                },
-                "visible": "[steps('instance').fazLicense.fazLicenseFortiFlexCheck]"
               }
             ]
           },
@@ -743,11 +420,11 @@
             "label": "Virtual Machine Name",
             "elements": [
               {
-                "name": "fazvmname",
+                "name": "fpamvmname",
                 "type": "Microsoft.Common.TextBox",
-                "label": "Name of the FortiAnalyzer VM",
-                "defaultValue": "[if(equals(basics('fortiAnalyzerNamePrefix'),''),'FortiAnalyzer-VM',concat(basics('fortiAnalyzerNamePrefix'),'-FGT'))]",
-                "toolTip": "Provide the name of the FortiAnalyzer VM. This is not required as a field.",
+                "label": "Name of the FortiPAM VM",
+                "defaultValue": "[if(equals(basics('namePrefix'),''),'FortiPAM-VM',concat(basics('namePrefix'),'-fpam'))]",
+                "toolTip": "Provide the name of the FortiPAM VM. This is not required as a field.",
                 "constraints": {
                   "required": false,
                   "regex": "^[A-Za-z0-9-]{1,64}$",
@@ -788,11 +465,11 @@
                   "subnets": "Subnets"
                 },
                 "toolTip": {
-                  "virtualNetwork": "Virtual Network for deployment of the FortiAnalyzer VM solution",
+                  "virtualNetwork": "Virtual Network for deployment of the FortiPAM VM solution",
                   "subnets": "Standard deployment is to have an "
                 },
                 "defaultValue": {
-                  "name": "[if(equals(basics('namePrefix'),''),'FortiAnalyzer-vnet',concat(basics('namePrefix'),'-vnet'))]",
+                  "name": "[if(equals(basics('namePrefix'),''),'FortiPAM-vnet',concat(basics('namePrefix'),'-vnet'))]",
                   "addressPrefixSize": "/24"
                 },
                 "constraints": {
@@ -803,7 +480,7 @@
                 },
                 "subnets": {
                   "subnet1": {
-                    "label": "FortiAnalyzer Subnet",
+                    "label": "FortiPAM Subnet",
                     "defaultValue": {
                       "name": "ProtectedSubnet",
                       "addressPrefixSize": "/26"
@@ -824,7 +501,7 @@
                 "options": {
                   "icon": "Info",
                   "text": "More information about the deployment can be found here.",
-                  "uri": "https://github.com/fortinet/azure-templates/tree/main/FortiAnalyzer/single"
+                  "uri": "https://github.com/40net-cloud/fortinet-azure-solutions/tree/main/FortiPAM/A-Single-VM"
                 }
               }
             ]
@@ -844,7 +521,7 @@
             "type": "Microsoft.Common.TextBlock",
             "visible": true,
             "options": {
-              "text": "The public IP will be used for connect to the FortiAnalyzer. The public IP is optional. Selecting none will result in a FortiAnalyzer that is not accessible from the public internet. Other means like VPN connection or Experess Route are needed to connect to the unit in that case."
+              "text": "The public IP will be used for connect to the FortiPAM. The public IP is optional. Selecting none will result in a FortiPAM that is not accessible from the public internet. Other means like VPN connection or Experess Route are needed to connect to the unit in that case."
             }
           },
           {
@@ -855,11 +532,11 @@
               "domainNameLabel": "Domain name label"
             },
             "toolTip": {
-              "publicIpAddress": "Public IP attached to FortiAnalyzer VM",
+              "publicIpAddress": "Public IP attached to FortiPAM VM",
               "domainNameLabel": "DNS name linked to this public IP"
             },
             "defaultValue": {
-              "publicIpAddressName": "[if(equals(basics('fortiAnalyzerNamePrefix'),''),'FAZPublicIP',concat(basics('fortiAnalyzerNamePrefix'),'-faz-pip'))]",
+              "publicIpAddressName": "[if(equals(basics('namePrefix'),''),'FPAMPublicIP',concat(basics('namePrefix'),'-fpam-pip'))]",
               "domainNameLabel": "mydomain"
             },
             "constraints": {
@@ -930,8 +607,8 @@
                 "visible": true,
                 "options": {
                   "icon": "Info",
-                  "text": "The default configuration already included in this deployment can be found on our github page. ",
-                  "uri": "https://github.com/fortinet/azure-templates/blob/main/FortiAnalyzer/single/doc/config-provisioning.md"
+                  "text": "FortiPAM is deployed without an injected configuration. License is uploaded post-deploy via SCP. See the FortiPAM Azure administration guide.",
+                  "uri": "https://docs.fortinet.com/document/fortipam-public-cloud/1.9.0/azure-administration-guide"
                 }
               }
             ]
@@ -981,8 +658,6 @@
       "availabilityOptions": "[steps('instance').availabilityOptions.availabilityOptions]",
       "existingAvailabilitySetName": "[steps('instance').availabilityOptions.availabilitySetSelector.name]",
       "availabilityZoneNumber": "[steps('instance').availabilityOptions.availabilityZoneSelector]",
-      "fortiAnalyzerLicenseBYOL": "[steps('instance').fazLicense.fazcontent]",
-      "fortiAnalyzerLicenseFortiFlex": "[steps('instance').fazLicense.fazfortiflex]",
       "publicIPNewOrExisting": "[steps('publicip').publicip.newOrExistingOrNone]",
       "publicIPName": "[steps('publicip').publicip.name]",
       "publicIPResourceGroup": "[steps('publicip').publicip.resourceGroup]",

--- a/FortiPAM/A-Single-VM/createUiDefinition.json
+++ b/FortiPAM/A-Single-VM/createUiDefinition.json
@@ -1,0 +1,1000 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+  "handler": "Microsoft.Azure.CreateUIDef",
+  "version": "0.1.2-preview",
+  "parameters": {
+    "config": {
+      "basics": {
+        "resourceGroup": {
+          "allowExisting": true
+        }
+      }
+    },
+    "resourceTypes": [
+      "microsoft.resources/resourcegroups"
+    ],
+    "basics": [
+      {
+        "name": "adminUsername",
+        "type": "Microsoft.Common.TextBox",
+        "label": "FortiAnalyzer administrative username",
+        "defaultValue": "",
+        "toolTip": "Username for the FortiAnalyzer virtual appliance. Most not be root, administrator or admin",
+        "constraints": {
+          "required": true,
+          "validations": [
+            {
+              "regex": "^[a-z0-9A-Z]{1,30}$",
+              "message": "Only alphanumeric characters are allowed, and the value must be 1-30 characters long"
+            },
+            {
+              "isValid": "[not(contains(toLower(basics('adminUsername')),'root'))]",
+              "message": "Usernames must not include reserved words"
+            },
+            {
+              "isValid": "[not(contains(toLower(basics('adminUsername')),'admin'))]",
+              "message": "Usernames must not include reserved words"
+            }
+          ]
+        },
+        "visible": true
+      },
+      {
+        "name": "adminPassword",
+        "type": "Microsoft.Common.PasswordBox",
+        "label": {
+          "password": "FortiAnalyzer password",
+          "confirmPassword": "Confirm password"
+        },
+        "toolTip": "Password for the Virtual Machine",
+        "constraints": {
+          "required": true,
+          "regex": "^(?:(?=.*[a-z])(?:(?=.*[A-Z])(?=.*[\\d\\W])|(?=.*\\W)(?=.*\\d))|(?=.*\\W)(?=.*[A-Z])(?=.*\\d)).{12,}$",
+          "validationMessage": "The password must be between 12 characters or longer, and contain characters from at least 3 of the following groups: uppercase characters, lowercase characters, numbers, and special characters excluding '\\' or '-'."
+        },
+        "options": {
+          "hideConfirmation": false
+        },
+        "visible": true
+      },
+      {
+        "name": "namePrefix",
+        "type": "Microsoft.Common.TextBox",
+        "label": "FortiAnalyzer Name Prefix",
+        "defaultValue": "",
+        "toolTip": "Naming prefix for all deployed resources",
+        "constraints": {
+          "required": true,
+          "regex": "^[A-Za-z0-9-]{1,15}$",
+          "validationMessage": "Only alphanumeric characters are allowed, and the value must be 1 to 15 characters."
+        },
+        "visible": true
+      },
+      {
+        "name": "imageSku",
+        "type": "Microsoft.Common.DropDown",
+        "label": "FortiAnalyzer Image SKU",
+        "defaultValue": "Bring Your Own License",
+        "toolTip": "BYOL license model (where license is purchased separately)",
+        "constraints": {
+          "required": false,
+          "allowedValues": [
+            {
+              "label": "Bring Your Own License",
+              "value": "fortinet-fortianalyzer"
+            }
+          ]
+        },
+        "visible": true
+      },
+      {
+        "name": "imageVersion",
+        "type": "Microsoft.Common.DropDown",
+        "label": "FortiAnalyzer Image Version",
+        "defaultValue": "7.6.3",
+        "toolTip": "Only 6.x has the A/P HA feature currently",
+        "constraints": {
+          "required": false,
+          "allowedValues": [
+            {
+              "label": "latest",
+              "value": "latest"
+            },
+            {
+              "label": "7.6.6",
+              "value": "7.6.6"
+            },
+            {
+              "label": "7.6.5",
+              "value": "7.6.5"
+            },
+            {
+              "label": "7.6.4",
+              "value": "7.6.4"
+            },
+            {
+              "label": "7.6.3",
+              "value": "7.6.3"
+            },
+            {
+              "label": "7.6.2",
+              "value": "7.6.2"
+            },
+            {
+              "label": "7.6.1",
+              "value": "7.6.1"
+            },
+            {
+              "label": "7.6.0",
+              "value": "7.6.0"
+            },
+            {
+              "label": "7.4.8",
+              "value": "7.4.8"
+            },
+            {
+              "label": "7.4.7",
+              "value": "7.4.7"
+            },
+            {
+              "label": "7.4.6",
+              "value": "7.4.6"
+            },
+            {
+              "label": "7.4.5",
+              "value": "7.4.5"
+            },
+            {
+              "label": "7.4.4",
+              "value": "7.4.4"
+            },
+            {
+              "label": "7.4.3",
+              "value": "7.4.3"
+            },
+            {
+              "label": "7.4.2",
+              "value": "7.4.2"
+            },
+            {
+              "label": "7.4.1",
+              "value": "7.4.1"
+            },
+            {
+              "label": "7.4.0",
+              "value": "7.4.0"
+            },
+            {
+              "label": "7.2.9",
+              "value": "7.2.9"
+            },
+            {
+              "label": "7.2.8",
+              "value": "7.2.8"
+            },
+            {
+              "label": "7.2.7",
+              "value": "7.2.7"
+            },
+            {
+              "label": "7.2.6",
+              "value": "7.2.6"
+            },
+            {
+              "label": "7.2.5",
+              "value": "7.2.5"
+            },
+            {
+              "label": "7.2.4",
+              "value": "7.2.4"
+            },
+            {
+              "label": "7.2.3",
+              "value": "7.2.3"
+            },
+            {
+              "label": "7.2.2",
+              "value": "7.2.2"
+            },
+            {
+              "label": "7.2.11",
+              "value": "7.2.11"
+            },
+            {
+              "label": "7.2.10",
+              "value": "7.2.10"
+            },
+            {
+              "label": "7.2.1",
+              "value": "7.2.1"
+            },
+            {
+              "label": "7.2.0",
+              "value": "7.2.0"
+            },
+            {
+              "label": "7.0.9",
+              "value": "7.0.9"
+            },
+            {
+              "label": "7.0.7",
+              "value": "7.0.7"
+            },
+            {
+              "label": "7.0.6",
+              "value": "7.0.6"
+            },
+            {
+              "label": "7.0.5",
+              "value": "7.0.5"
+            },
+            {
+              "label": "7.0.4",
+              "value": "7.0.4"
+            },
+            {
+              "label": "7.0.3",
+              "value": "7.0.3"
+            },
+            {
+              "label": "7.0.2",
+              "value": "7.0.2"
+            },
+            {
+              "label": "7.0.14",
+              "value": "7.0.14"
+            },
+            {
+              "label": "7.0.13",
+              "value": "7.0.13"
+            },
+            {
+              "label": "7.0.12",
+              "value": "7.0.12"
+            },
+            {
+              "label": "7.0.11",
+              "value": "7.0.11"
+            },
+            {
+              "label": "7.0.10",
+              "value": "7.0.10"
+            },
+            {
+              "label": "7.0.1",
+              "value": "7.0.1"
+            },
+            {
+              "label": "7.0.0",
+              "value": "7.0.0"
+            },
+            {
+              "label": "6.4.9",
+              "value": "6.4.9"
+            },
+            {
+              "label": "6.4.8",
+              "value": "6.4.8"
+            },
+            {
+              "label": "6.4.7",
+              "value": "6.4.7"
+            },
+            {
+              "label": "6.4.6",
+              "value": "6.4.6"
+            },
+            {
+              "label": "6.4.5",
+              "value": "6.4.5"
+            },
+            {
+              "label": "6.4.2",
+              "value": "6.4.2"
+            },
+            {
+              "label": "6.4.15",
+              "value": "6.4.15"
+            },
+            {
+              "label": "6.4.14",
+              "value": "6.4.14"
+            },
+            {
+              "label": "6.4.13",
+              "value": "6.4.13"
+            },
+            {
+              "label": "6.4.12",
+              "value": "6.4.12"
+            },
+            {
+              "label": "6.4.11",
+              "value": "6.4.11"
+            },
+            {
+              "label": "6.4.10",
+              "value": "6.4.10"
+            },
+            {
+              "label": "6.4.1",
+              "value": "6.4.1"
+            },
+            {
+              "label": "6.4.0",
+              "value": "6.4.0"
+            },
+            {
+              "label": "6.2.5",
+              "value": "6.2.5"
+            },
+            {
+              "label": "6.2.3",
+              "value": "6.2.3"
+            },
+            {
+              "label": "6.2.2",
+              "value": "6.2.2"
+            },
+            {
+              "label": "6.2.1",
+              "value": "6.2.1"
+            },
+            {
+              "label": "6.2.0",
+              "value": "6.2.0"
+            }
+          ]
+        },
+        "visible": true
+      }
+    ],
+    "steps": [
+      {
+        "name": "instance",
+        "label": "Instance",
+        "subLabel": {
+          "preValidation": "Select instance type",
+          "postValidation": "Done"
+        },
+        "elements": [
+          {
+            "name": "instancetype",
+            "type": "Microsoft.Common.Section",
+            "label": "Instance Type",
+            "elements": [
+              {
+                "name": "instancetypeinfo",
+                "type": "Microsoft.Common.TextBlock",
+                "visible": true,
+                "options": {
+                  "text": "For this FortiAnalyzer deployment, it is recommended to use general purpose virtual machines. A selection of supported instances sizes is listed in our documentation.",
+                  "link": {
+                    "label": "Learn more",
+                    "uri": "https://docs.fortinet.com/document/fortianalyzer-public-cloud/7.2.0/azure-administration-guide/351055"
+                  }
+                }
+              },
+              {
+                "name": "instancetypeselection",
+                "type": "Microsoft.Compute.SizeSelector",
+                "label": "Size",
+                "toolTip": "Select the instance size of your FortiAnalyzer VM solution. Minimum 4 NICs are required.",
+                "recommendedSizes": [
+                  "Standard_DS4_v2",
+                  "Standard_DS5_v2",
+                  "Standard_D4_v3",
+                  "Standard_D8_v3",
+                  "Standard_D16_v3",
+                  "Standard_D4a_v4",
+                  "Standard_D8a_v4",
+                  "Standard_D16a_v4",
+                  "Standard_D32a_v4",
+                  "Standard_D48a_v4",
+                  "Standard_D64a_v4",
+                  "Standard_D96a_v4",
+                  "Standard_D4as_v4",
+                  "Standard_D8as_v4",
+                  "Standard_D16as_v4",
+                  "Standard_D32as_v4",
+                  "Standard_D48as_v4",
+                  "Standard_D64as_v4",
+                  "Standard_D96as_v4",
+                  "Standard_D4_v5",
+                  "Standard_D8_v5",
+                  "Standard_D16_v5",
+                  "Standard_D32_v5",
+                  "Standard_D48_v5",
+                  "Standard_D64_v5",
+                  "Standard_D96_v5",
+                  "Standard_D4s_v5",
+                  "Standard_D8s_v5",
+                  "Standard_D16s_v5",
+                  "Standard_D32s_v5",
+                  "Standard_D48s_v5",
+                  "Standard_D64s_v5",
+                  "Standard_D96s_v5"
+                ],
+                "constraints": {
+                  "allowedValues": [
+                    "Standard_DS4_v2",
+                    "Standard_DS5_v2",
+                    "Standard_D4_v3",
+                    "Standard_D8_v3",
+                    "Standard_D16_v3",
+                    "Standard_D4a_v4",
+                    "Standard_D8a_v4",
+                    "Standard_D16a_v4",
+                    "Standard_D32a_v4",
+                    "Standard_D48a_v4",
+                    "Standard_D64a_v4",
+                    "Standard_D96a_v4",
+                    "Standard_D4as_v4",
+                    "Standard_D8as_v4",
+                    "Standard_D16as_v4",
+                    "Standard_D32as_v4",
+                    "Standard_D48as_v4",
+                    "Standard_D64as_v4",
+                    "Standard_D96as_v4",
+                    "Standard_D4_v5",
+                    "Standard_D8_v5",
+                    "Standard_D16_v5",
+                    "Standard_D32_v5",
+                    "Standard_D48_v5",
+                    "Standard_D64_v5",
+                    "Standard_D96_v5",
+                    "Standard_D4s_v5",
+                    "Standard_D8s_v5",
+                    "Standard_D16s_v5",
+                    "Standard_D32s_v5",
+                    "Standard_D48s_v5",
+                    "Standard_D64s_v5",
+                    "Standard_D96s_v5"
+                  ]
+                },
+                "options": {
+                  "hideDiskTypeFilter": false
+                },
+                "osPlatform": "Linux",
+                "imageReference": {
+                  "publisher": "fortinet",
+                  "offer": "fortinet-fortianalyzer",
+                  "sku": "fortinet-fortianalyzer"
+                },
+                "count": 1,
+                "visible": true
+              }
+            ]
+          },
+          {
+            "name": "datadisk",
+            "type": "Microsoft.Common.Section",
+            "label": "Data Disk",
+            "elements": [
+              {
+                "name": "vmDataDiskCount",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Number of managed disks per data node",
+                "defaultValue": "1",
+                "toolTip": "Number of disks to attach to the FortiAnalyzer.",
+                "constraints": {
+                  "required": true,
+                  "regex": "^([0-9]|1[0-5])$",
+                  "validationMessage": "Value must be numeric and greater than or equal to 0"
+                }
+              },
+              {
+                "name": "vmDataDiskSize",
+                "type": "Microsoft.Common.DropDown",
+                "label": "Size of each managed disk",
+                "visible": "[greater(steps('instance').datadisk.vmDataDiskCount, 0)]",
+                "defaultValue": "1TiB",
+                "toolTip": "The size of each data disk to attach to the FortiAnalyzer",
+                "constraints": {
+                  "allowedValues": [
+                    {
+                      "label": "32GiB",
+                      "value": "32"
+                    },
+                    {
+                      "label": "64GiB",
+                      "value": "64"
+                    },
+                    {
+                      "label": "128GiB",
+                      "value": "128"
+                    },
+                    {
+                      "label": "256GiB",
+                      "value": "256"
+                    },
+                    {
+                      "label": "512GiB",
+                      "value": "512"
+                    },
+                    {
+                      "label": "1TiB",
+                      "value": "1024"
+                    },
+                    {
+                      "label": "2TiB",
+                      "value": "2048"
+                    },
+                    {
+                      "label": "4TiB",
+                      "value": "4096"
+                    },
+                    {
+                      "label": "8TiB",
+                      "value": "8192"
+                    },
+                    {
+                      "label": "16TiB",
+                      "value": "16384"
+                    },
+                    {
+                      "label": "32TiB",
+                      "value": "32768"
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "diskType",
+                "type": "Microsoft.Common.DropDown",
+                "label": "Type of managed disks",
+                "visible": "[greater(steps('instance').datadisk.vmDataDiskCount, 0)]",
+                "defaultValue": "Default disks for instance type",
+                "toolTip": "The storage type of managed disks. The default will be Premium disks for VMs that support Premium disks and Standard disks for those that do not.",
+                "constraints": {
+                  "allowedValues": [
+                    {
+                      "label": "Default disks for instance type",
+                      "value": "Default"
+                    },
+                    {
+                      "label": "Standard SSD disks - LRS",
+                      "value": "StandardSSD_LRS"
+                    },
+                    {
+                      "label": "Standard SSD disks - ZRS",
+                      "value": "StandardSSD_ZRS"
+                    },
+                    {
+                      "label": "Premium SSD disks - LRS",
+                      "value": "Premium_LRS"
+                    },
+                    {
+                      "label": "Premium SSD disks - ZRS",
+                      "value": "Premium_ZRS"
+                    },
+                    {
+                      "label": "Standard HDD disks - LRS",
+                      "value": "Standard_LRS"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "name": "availabilityOptions",
+            "type": "Microsoft.Common.Section",
+            "label": "Availability Options",
+            "elements": [
+              {
+                "name": "availabilityOptionsHeader",
+                "type": "Microsoft.Common.TextBlock",
+                "visible": true,
+                "options": {
+                  "text": "Deploy FortiAnalyzer VMs in an availability set or availability zone.",
+                  "link": {
+                    "label": "Learn more",
+                    "uri": "https://github.com/fortinet/azure-templates/tree/main/FortiGate#sla"
+                  }
+                }
+              },
+              {
+                "name": "availabilityOptions",
+                "type": "Microsoft.Common.DropDown",
+                "label": "Availability Option",
+                "defaultValue": "No infrastructure redundancy required",
+                "toolTip": "Deploy FortiAnalyzer VMs in a new or existing availability set or or a specific availability zone.",
+                "constraints": {
+                  "required": false,
+                  "allowedValues": [
+                    {
+                      "label": "No infrastructure redundancy required",
+                      "value": "None"
+                    },
+                    {
+                      "label": "Availability set",
+                      "value": "Availability set"
+                    },
+                    {
+                      "label": "Availability zone",
+                      "value": "Availability zone"
+                    }
+                  ]
+                },
+                "visible": true
+              },
+              {
+                "name": "availabilitySetNew",
+                "type": "Microsoft.Common.CheckBox",
+                "label": "Create a new availability set?",
+                "toolTip": "Check this box if you want to create a new availability set and add the FortiAnalyzer VM to it.",
+                "visible": "[equals(steps('instance').availabilityOptions.availabilityOptions,'Availability set')]"
+              },
+              {
+                "name": "availabilitySetSelector",
+                "type": "Microsoft.Solutions.ResourceSelector",
+                "label": "Select the availability set for your FortiAnalyzer",
+                "toolTip": "Select your existing availability set you want to add this FortiAnalyzer VM to",
+                "resourceType": "Microsoft.Compute/availabilitySets",
+                "options": {
+                  "filter": {
+                    "subscription": "onBasics",
+                    "location": "onBasics"
+                  }
+                },
+                "visible": "[and(not(steps('instance').availabilityOptions.availabilitySetNew),equals(steps('instance').availabilityOptions.availabilityOptions,'Availability set'))]"
+              },
+              {
+                "name": "availabilitySetInfo",
+                "type": "Microsoft.Common.InfoBox",
+                "options": {
+                  "icon": "Info",
+                  "text": "The FortiAnalyzer VM and availability set are required to exist in the same resource group."
+                },
+                "visible": "[and(not(steps('instance').availabilityOptions.availabilitySetNew),equals(steps('instance').availabilityOptions.availabilityOptions,'Availability set'))]"
+              },
+              {
+                "name": "availabilityZoneSelector",
+                "type": "Microsoft.Common.DropDown",
+                "label": "Select the availability zone for your FortiAnalyzer VM",
+                "toolTip": "Select the availability zone for your FortiAnalyzer VM",
+                "defaultValue": "Zone 2",
+                "constraints": {
+                  "allowedValues": [
+                    {
+                      "label": "Zone 1",
+                      "value": "1"
+                    },
+                    {
+                      "label": "Zone 2",
+                      "value": "2"
+                    },
+                    {
+                      "label": "Zone 3",
+                      "value": "3"
+                    }
+                  ]
+                },
+                "visible": "[equals(steps('instance').availabilityOptions.availabilityOptions,'Availability zone')]"
+              },
+              {
+                "name": "availabilityOptionsFooter",
+                "type": "Microsoft.Common.InfoBox",
+                "visible": true,
+                "options": {
+                  "icon": "Info",
+                  "text": "If availability zone deployment is selected but the location does not support availability zone an availability set will be deployed. If availability zone deployment is selected and availability zone are available in the location, FortiAnalyzer A will be placed in Zone 1, FortiAnalyzer B will be placed in Zone 2",
+                  "uri": "https://docs.microsoft.com/en-us/azure/availability-zones/az-overview"
+                }
+              }
+            ]
+          },
+          {
+            "name": "fazLicense",
+            "type": "Microsoft.Common.Section",
+            "label": "FortiAnalyzer License",
+            "elements": [
+              {
+                "name": "fazLicenseBYOLInfo",
+                "type": "Microsoft.Common.TextBlock",
+                "visible": true,
+                "options": {
+                  "text": "The Bring Your Own license file(s), retrieved from support.fortinet.com, can be uploaded here or uploaded after deployment."
+                }
+              },
+              {
+                "name": "fazLicenseFortiFlexCheck",
+                "type": "Microsoft.Common.CheckBox",
+                "label": "My organisation is using the FortiFlex subscription service.",
+                "toolTip": "Select this box to enter a FortiFlex token",
+                "visible": true
+              },
+              {
+                "name": "fazcontent",
+                "type": "Microsoft.Common.FileUpload",
+                "label": "FortiAnalyzer License",
+                "toolTip": "Upload the license file for the FortiAnalyzer BYOL here.",
+                "constraints": {
+                  "required": false,
+                  "accept": ".lic,.txt"
+                },
+                "options": {
+                  "multiple": false,
+                  "uploadMode": "file",
+                  "openMode": "text",
+                  "encoding": "UTF-8"
+                },
+                "visible": "[not(steps('instance').fazLicense.fazLicenseFortiFlexCheck)]"
+              },
+              {
+                "name": "fazfortiflex",
+                "type": "Microsoft.Common.TextBox",
+                "label": "FortiAnalyzer FortiFlex",
+                "defaultValue": "",
+                "toolTip": "FortiAnalyzer FortiFlex license token",
+                "constraints": {
+                  "required": false,
+                  "regex": "^[A-Za-z0-9-]{1,64}$",
+                  "validationMessage": "Only alphanumeric characters and a dash are allowed, and the value must be 1 to 64 characters."
+                },
+                "visible": "[steps('instance').fazLicense.fazLicenseFortiFlexCheck]"
+              }
+            ]
+          },
+          {
+            "name": "virtualmachinename",
+            "type": "Microsoft.Common.Section",
+            "label": "Virtual Machine Name",
+            "elements": [
+              {
+                "name": "fazvmname",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Name of the FortiAnalyzer VM",
+                "defaultValue": "[if(equals(basics('fortiAnalyzerNamePrefix'),''),'FortiAnalyzer-VM',concat(basics('fortiAnalyzerNamePrefix'),'-FGT'))]",
+                "toolTip": "Provide the name of the FortiAnalyzer VM. This is not required as a field.",
+                "constraints": {
+                  "required": false,
+                  "regex": "^[A-Za-z0-9-]{1,64}$",
+                  "validationMessage": "Only alphanumeric characters and a dash are allowed, and the value must be 1 to 64 characters."
+                },
+                "visible": true
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "networking",
+        "label": "Networking",
+        "subLabel": {
+          "preValidation": "Configure internal networking",
+          "postValidation": "Done"
+        },
+        "elements": [
+          {
+            "name": "virtualnetworksection",
+            "type": "Microsoft.Common.Section",
+            "label": "Configure Internal Networking",
+            "elements": [
+              {
+                "name": "virtualnetworktext",
+                "type": "Microsoft.Common.TextBlock",
+                "visible": true,
+                "options": {
+                  "text": "Create a new or select an existing virtual network with the required subnets."
+                }
+              },
+              {
+                "name": "virtualnetwork",
+                "type": "Microsoft.Network.VirtualNetworkCombo",
+                "label": {
+                  "virtualNetwork": "Virtual network",
+                  "subnets": "Subnets"
+                },
+                "toolTip": {
+                  "virtualNetwork": "Virtual Network for deployment of the FortiAnalyzer VM solution",
+                  "subnets": "Standard deployment is to have an "
+                },
+                "defaultValue": {
+                  "name": "[if(equals(basics('namePrefix'),''),'FortiAnalyzer-vnet',concat(basics('namePrefix'),'-vnet'))]",
+                  "addressPrefixSize": "/24"
+                },
+                "constraints": {
+                  "minAddressPrefixSize": "/29"
+                },
+                "options": {
+                  "hideExisting": false
+                },
+                "subnets": {
+                  "subnet1": {
+                    "label": "FortiAnalyzer Subnet",
+                    "defaultValue": {
+                      "name": "ProtectedSubnet",
+                      "addressPrefixSize": "/26"
+                    },
+                    "constraints": {
+                      "minAddressPrefixSize": "/29",
+                      "minAddressCount": 1,
+                      "requireContiguousAddresses": true
+                    }
+                  }
+                },
+                "visible": true
+              },
+              {
+                "name": "virtualnetworkinfo",
+                "type": "Microsoft.Common.InfoBox",
+                "visible": true,
+                "options": {
+                  "icon": "Info",
+                  "text": "More information about the deployment can be found here.",
+                  "uri": "https://github.com/fortinet/azure-templates/tree/main/FortiAnalyzer/single"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "publicip",
+        "label": "Public IP",
+        "subLabel": {
+          "preValidation": "Configure public networking",
+          "postValidation": "Done"
+        },
+        "elements": [
+          {
+            "name": "publiciptext",
+            "type": "Microsoft.Common.TextBlock",
+            "visible": true,
+            "options": {
+              "text": "The public IP will be used for connect to the FortiAnalyzer. The public IP is optional. Selecting none will result in a FortiAnalyzer that is not accessible from the public internet. Other means like VPN connection or Experess Route are needed to connect to the unit in that case."
+            }
+          },
+          {
+            "name": "publicip",
+            "type": "Microsoft.Network.PublicIpAddressCombo",
+            "label": {
+              "publicIpAddress": "Public IP address",
+              "domainNameLabel": "Domain name label"
+            },
+            "toolTip": {
+              "publicIpAddress": "Public IP attached to FortiAnalyzer VM",
+              "domainNameLabel": "DNS name linked to this public IP"
+            },
+            "defaultValue": {
+              "publicIpAddressName": "[if(equals(basics('fortiAnalyzerNamePrefix'),''),'FAZPublicIP',concat(basics('fortiAnalyzerNamePrefix'),'-faz-pip'))]",
+              "domainNameLabel": "mydomain"
+            },
+            "constraints": {
+              "required": {
+                "domainNameLabel": false
+              }
+            },
+            "options": {
+              "hideNone": false,
+              "hideDomainNameLabel": true
+            },
+            "visible": true
+          },
+          {
+            "name": "standardsku",
+            "type": "Microsoft.Common.InfoBox",
+            "visible": true,
+            "options": {
+              "icon": "Info",
+              "text": "This deployment can use standard or basic SKU public IP's. Microsoft Azure offers a migration path from a basic to standard SKU public IP.",
+              "uri": "https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-public-ip-address-upgrade?tabs=option-upgrade-cli%2Coption-migrate-powershell"
+            }
+          }
+        ]
+      },
+      {
+        "name": "advanced",
+        "label": "Advanced",
+        "subLabel": {
+          "preValidation": "Configure central management",
+          "postValidation": "Done"
+        },
+        "elements": [
+          {
+            "name": "customdata",
+            "type": "Microsoft.Common.Section",
+            "label": "Custom Data",
+            "elements": [
+              {
+                "name": "customdatatext",
+                "type": "Microsoft.Common.TextBlock",
+                "visible": true,
+                "options": {
+                  "text": "Pass a configuration file into the virtual machine while it is being provisioned. This is additional to the configuration for this architecture."
+                }
+              },
+              {
+                "name": "config",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Custom Data",
+                "toolTip": "Custom Data",
+                "placeholder": "Add you required additional configuration here.",
+                "multiLine": true,
+                "constraints": {
+                  "required": false,
+                  "validations": [
+                    {
+                      "regex": "^[\\w\\W\n\t]{0,10240}$",
+                      "message": "All characters allowed, max 10240 characters."
+                    }
+                  ]
+                },
+                "visible": true
+              },
+              {
+                "name": "standardsku",
+                "type": "Microsoft.Common.InfoBox",
+                "visible": true,
+                "options": {
+                  "icon": "Info",
+                  "text": "The default configuration already included in this deployment can be found on our github page. ",
+                  "uri": "https://github.com/fortinet/azure-templates/blob/main/FortiAnalyzer/single/doc/config-provisioning.md"
+                }
+              }
+            ]
+          },
+          {
+            "name": "serialconsole",
+            "type": "Microsoft.Common.Section",
+            "label": "Serial Console",
+            "elements": [
+              {
+                "name": "enabled",
+                "type": "Microsoft.Common.OptionsGroup",
+                "label": "Enable Serial Console",
+                "defaultValue": "yes",
+                "toolTip": "Enables the serial console.",
+                "constraints": {
+                  "allowedValues": [
+                    {
+                      "label": "yes",
+                      "value": "yes"
+                    },
+                    {
+                      "label": "no",
+                      "value": "no"
+                    }
+                  ],
+                  "required": true
+                },
+                "visible": true
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "outputs": {
+      "namePrefix": "[basics('namePrefix')]",
+      "imageSku": "[basics('imageSku')]",
+      "imageVersion": "[basics('imageVersion')]",
+      "adminUsername": "[basics('adminUsername')]",
+      "adminPassword": "[basics('adminPassword')]",
+      "location": "[location()]",
+      "instanceType": "[steps('instance').instancetype.instancetypeselection]",
+      "dataDiskCount": "[steps('instance').datadisk.vmDataDiskCount]",
+      "dataDiskSize": "[steps('instance').datadisk.vmDataDiskSize]",
+      "diskType": "[steps('instance').datadisk.diskType]",
+      "availabilityOptions": "[steps('instance').availabilityOptions.availabilityOptions]",
+      "existingAvailabilitySetName": "[steps('instance').availabilityOptions.availabilitySetSelector.name]",
+      "availabilityZoneNumber": "[steps('instance').availabilityOptions.availabilityZoneSelector]",
+      "fortiAnalyzerLicenseBYOL": "[steps('instance').fazLicense.fazcontent]",
+      "fortiAnalyzerLicenseFortiFlex": "[steps('instance').fazLicense.fazfortiflex]",
+      "publicIPNewOrExisting": "[steps('publicip').publicip.newOrExistingOrNone]",
+      "publicIPName": "[steps('publicip').publicip.name]",
+      "publicIPResourceGroup": "[steps('publicip').publicip.resourceGroup]",
+      "vnetNewOrExisting": "[steps('networking').virtualnetworksection.virtualnetwork.newOrExisting]",
+      "vnetName": "[steps('networking').virtualnetworksection.virtualnetwork.name]",
+      "vnetResourceGroup": "[steps('networking').virtualnetworksection.virtualnetwork.resourceGroup]",
+      "vnetAddressPrefix": "[steps('networking').virtualnetworksection.virtualnetwork.addressPrefix]",
+      "subnet1Name": "[steps('networking').virtualnetworksection.virtualnetwork.subnets.subnet1.name]",
+      "subnet1Prefix": "[steps('networking').virtualnetworksection.virtualnetwork.subnets.subnet1.addressPrefix]",
+      "subnet1StartAddress": "[steps('networking').virtualnetworksection.virtualnetwork.subnets.subnet1.startAddress]",
+      "serialConsole": "[steps('advanced').serialconsole.enabled]",
+      "additionalCustomData": "[steps('advanced').customdata.config]"
+    }
+  }
+}

--- a/FortiPAM/A-Single-VM/deploy.sh
+++ b/FortiPAM/A-Single-VM/deploy.sh
@@ -2,13 +2,13 @@
 echo "
 ##############################################################################################################
 #
-# Deployment of a FortiAnalyzer VM
+# Deployment of a FortiPAM VM
 #
 ##############################################################################################################
 
 "
-#echo "--> Auto accepting terms for Azure Marketplace deployments ..."
-#az vm image terms accept --publisher fortinet --offer fortinet-fortianalyzer --plan fortinet-fortianalyzer
+echo "--> Accepting Azure Marketplace terms for FortiPAM (required before first deploy) ..."
+az vm image terms accept --urn fortinet:fortinet-fortipam:fortinet-fpam:1.9.0
 
 # Stop on error
 set +e
@@ -114,7 +114,7 @@ else
 echo "
 ##############################################################################################################
 #
-# FortiAnalyzer Azure deployment using ARM Template
+# FortiPAM Azure deployment using ARM Template
 #
 ##############################################################################################################
 
@@ -122,7 +122,7 @@ Deployment information:
 
 Username: $username
 
-FortiAnalyzer IP addesses
+FortiPAM IP addesses
 "
 query="[?virtualMachine.name.starts_with(@, '$prefix')].{virtualMachine:virtualMachine.name, publicIP:virtualMachine.network.publicIpAddresses[0].ipAddress,privateIP:virtualMachine.network.privateIpAddresses[0]}"
 az vm list-ip-addresses --query "$query" --output tsv

--- a/FortiPAM/A-Single-VM/deploy.sh
+++ b/FortiPAM/A-Single-VM/deploy.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+echo "
+##############################################################################################################
+#
+# Deployment of a FortiAnalyzer VM
+#
+##############################################################################################################
+
+"
+#echo "--> Auto accepting terms for Azure Marketplace deployments ..."
+#az vm image terms accept --publisher fortinet --offer fortinet-fortianalyzer --plan fortinet-fortianalyzer
+
+# Stop on error
+set +e
+
+if [ -z "$DEPLOY_LOCATION" ]
+then
+    # Input location
+    echo -n "Enter location (e.g. eastus2): "
+    stty_orig=`stty -g` # save original terminal setting.
+    read location         # read the location
+    stty $stty_orig     # restore terminal setting.
+    if [ -z "$location" ]
+    then
+        location="eastus2"
+    fi
+else
+    location="$DEPLOY_LOCATION"
+fi
+echo ""
+echo "--> Deployment in '$location' location ..."
+
+if [ -z "$DEPLOY_PREFIX" ]
+then
+    echo ""
+    # Input prefix
+    echo -n "Enter prefix: "
+    stty_orig=`stty -g` # save original terminal setting.
+    read prefix         # read the prefix
+    stty $stty_orig     # restore terminal setting.
+    if [ -z "$prefix" ]
+    then
+        prefix="FORTI"
+    fi
+else
+    prefix="$DEPLOY_PREFIX"
+fi
+echo ""
+echo "--> Using prefix '$prefix' for all resources ..."
+echo ""
+rg="$prefix-RG"
+
+if [ -z "$DEPLOY_USERNAME" ]
+then
+    # Input username
+    echo -n "Enter username (default: azureuser): "
+    stty_orig=`stty -g` # save original terminal setting.
+    read username         # read the prefix
+    stty $stty_orig     # restore terminal setting.
+    if [ -z "$username" ]
+    then
+        username="azureuser"
+    fi
+else
+    username="$DEPLOY_USERNAME"
+fi
+echo ""
+echo "--> Using username '$username' ..."
+echo ""
+
+if [ -z "$DEPLOY_PASSWORD" ]
+then
+    # Input password
+    echo -n "Enter password: "
+    stty_orig=`stty -g` # save original terminal setting.
+    stty -echo          # turn-off echoing.
+    read passwd         # read the password
+    stty $stty_orig     # restore terminal setting.
+else
+    passwd="$DEPLOY_PASSWORD"
+    echo ""
+    echo "--> Using password found in env variable DEPLOY_PASSWORD ..."
+    echo ""
+fi
+
+# Create resource group
+echo ""
+echo "--> Creating $rg resource group ..."
+az group create --location "$location" --name "$rg"
+
+# Template validation
+echo "--> Validation deployment in $rg resource group ..."
+az deployment group validate --resource-group "$rg" \
+                           --template-file mainTemplate.json \
+                           --parameters adminUsername="$username" adminPassword="$passwd" namePrefix="$prefix"
+result=$?
+if [ $result != 0 ];
+then
+    echo "--> Validation failed ..."
+    exit $result;
+fi
+
+# Template deployment
+echo "--> Deployment of $rg resources ..."
+az deployment group create --confirm-with-what-if --resource-group "$rg" \
+                           --template-file mainTemplate.json \
+                           --parameters adminUsername="$username" adminPassword="$passwd" namePrefix="$prefix"
+result=$?
+if [[ $result != 0 ]];
+then
+    echo "--> Deployment failed ..."
+    exit $result;
+else
+echo "
+##############################################################################################################
+#
+# FortiAnalyzer Azure deployment using ARM Template
+#
+##############################################################################################################
+
+Deployment information:
+
+Username: $username
+
+FortiAnalyzer IP addesses
+"
+query="[?virtualMachine.name.starts_with(@, '$prefix')].{virtualMachine:virtualMachine.name, publicIP:virtualMachine.network.publicIpAddresses[0].ipAddress,privateIP:virtualMachine.network.privateIpAddresses[0]}"
+az vm list-ip-addresses --query "$query" --output tsv
+echo "
+##############################################################################################################
+"
+fi
+
+exit 0

--- a/FortiPAM/A-Single-VM/mainTemplate.json
+++ b/FortiPAM/A-Single-VM/mainTemplate.json
@@ -17,88 +17,31 @@
     "namePrefix": {
       "type": "string",
       "metadata": {
-        "description": "Name for FortiAnalyzer virtual appliances (A & B will be appended to the end of each respectively)"
+        "description": "Name for FortiPAM virtual appliances (A & B will be appended to the end of each respectively)"
       }
     },
     "imageSku": {
       "type": "string",
-      "defaultValue": "fortinet-fortianalyzer",
+      "defaultValue": "fortinet-fpam",
       "allowedValues": [
-        "fortinet-fortianalyzer"
+        "fortinet-fpam"
       ],
       "metadata": {
-        "description": "Identifies the license model"
+        "description": "FortiPAM marketplace plan/sku"
       }
     },
     "imageVersion": {
       "type": "string",
-      "defaultValue": "7.4.6",
+      "defaultValue": "1.9.0",
       "allowedValues": [
         "latest",
-        "7.6.6",
-        "7.6.5",
-        "7.6.4",
-        "7.6.3",
-        "7.6.2",
-        "7.6.1",
-        "7.6.0",
-        "7.4.8",
-        "7.4.7",
-        "7.4.6",
-        "7.4.5",
-        "7.4.4",
-        "7.4.3",
-        "7.4.2",
-        "7.4.1",
-        "7.4.0",
-        "7.2.9",
-        "7.2.8",
-        "7.2.7",
-        "7.2.6",
-        "7.2.5",
-        "7.2.4",
-        "7.2.3",
-        "7.2.2",
-        "7.2.11",
-        "7.2.10",
-        "7.2.1",
-        "7.2.0",
-        "7.0.9",
-        "7.0.7",
-        "7.0.6",
-        "7.0.5",
-        "7.0.4",
-        "7.0.3",
-        "7.0.2",
-        "7.0.14",
-        "7.0.13",
-        "7.0.12",
-        "7.0.11",
-        "7.0.10",
-        "7.0.1",
-        "7.0.0",
-        "6.4.9",
-        "6.4.8",
-        "6.4.7",
-        "6.4.6",
-        "6.4.5",
-        "6.4.2",
-        "6.4.15",
-        "6.4.14",
-        "6.4.13",
-        "6.4.12",
-        "6.4.11",
-        "6.4.10",
-        "6.4.1",
-        "6.4.0",
-        "6.2.5",
-        "6.2.3",
-        "6.2.2",
-        "6.2.1",
-        "6.2.0"
+        "1.9.0",
+        "1.7.0",
+        "1.3.0",
+        "1.1.2"
       ],
       "metadata": {
-        "description": "FortiAnalyzer version"
+        "description": "FortiPAM version"
       }
     },
     "additionalCustomData": {
@@ -117,20 +60,6 @@
         "Standard_D4_v3",
         "Standard_D8_v3",
         "Standard_D16_v3",
-        "Standard_D4a_v4",
-        "Standard_D8a_v4",
-        "Standard_D16a_v4",
-        "Standard_D32a_v4",
-        "Standard_D48a_v4",
-        "Standard_D64a_v4",
-        "Standard_D96a_v4",
-        "Standard_D4as_v4",
-        "Standard_D8as_v4",
-        "Standard_D16as_v4",
-        "Standard_D32as_v4",
-        "Standard_D48as_v4",
-        "Standard_D64as_v4",
-        "Standard_D96as_v4",
         "Standard_D4_v5",
         "Standard_D8_v5",
         "Standard_D16_v5",
@@ -159,21 +88,21 @@
       ],
       "defaultValue": "None",
       "metadata": {
-        "description": "Deploy FortiAnalyzer VM in an Availability Set or Availability Zones. If Availability Zones deployment is selected but the location does not support Availability Zones an Availability Set will be deployed. If Availability Zones deployment is selected and Availability Zones are available in the location, FortiAnalyzer A will be placed in Zone 1, FortiAnalyzer B will be placed in Zone 2"
+        "description": "Deploy FortiPAM VM in an Availability Set or Availability Zones. If Availability Zones deployment is selected but the location does not support Availability Zones an Availability Set will be deployed. If Availability Zones deployment is selected and Availability Zones are available in the location, FortiPAM A will be placed in Zone 1, FortiPAM B will be placed in Zone 2"
       }
     },
     "existingAvailabilitySetName": {
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "Name of existing Availability Set in case you want to replace or add a FortiAnalyzer to an existing cluster."
+        "description": "Name of existing Availability Set in case you want to replace or add a FortiPAM to an existing cluster."
       }
     },
     "availabilityZoneNumber": {
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "Name of existing Availability Set in case you want to replace or add a FortiAnalyzer to an existing cluster."
+        "description": "Name of existing Availability Set in case you want to replace or add a FortiPAM to an existing cluster."
       }
     },
     "publicIPNewOrExisting": {
@@ -185,12 +114,12 @@
         "none"
       ],
       "metadata": {
-        "description": "Choose between an existing, new or no public IP for the FortiAnalyzer VM"
+        "description": "Choose between an existing, new or no public IP for the FortiPAM VM"
       }
     },
     "publicIPName": {
       "type": "string",
-      "defaultValue": "FAZPublicIP",
+      "defaultValue": "FPAMPublicIP",
       "metadata": {
         "description": "Name of Public IP address element"
       }
@@ -236,16 +165,16 @@
     },
     "subnet1Name": {
       "type": "string",
-      "defaultValue": "FortiAnalyzerSubnet",
+      "defaultValue": "FortiPAMSubnet",
       "metadata": {
-        "description": "FortiAnalyzer Subnet"
+        "description": "FortiPAM Subnet"
       }
     },
     "subnet1Prefix": {
       "type": "string",
       "defaultValue": "172.16.137.0/24",
       "metadata": {
-        "description": "FortiAnalyzer Subnet Prefix"
+        "description": "FortiPAM Subnet Prefix"
       }
     },
     "subnet1StartAddress": {
@@ -283,30 +212,16 @@
     },
     "dataDiskSize": {
       "type": "string",
-      "defaultValue": "1024",
+      "defaultValue": "128",
       "metadata": {
-        "description": "Size of the logfile data disk"
+        "description": "Size of each FortiPAM data disk (GB). FortiPAM uses two disks: log and video (min 10 GB each, recommended log:video ratio 1:3)."
       }
     },
     "dataDiskCount": {
       "type": "int",
-      "defaultValue": 1,
+      "defaultValue": 2,
       "metadata": {
-        "description": "Number of data disk"
-      }
-    },
-    "fortiAnalyzerLicenseBYOL": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "FortiAnalyzer BYOL license content"
-      }
-    },
-    "fortiAnalyzerLicenseFortiFlex": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "FortiAnalyzer BYOL FortiFlex license token"
+        "description": "Number of data disks (FortiPAM uses 2: log + video)"
       }
     },
     "location": {
@@ -320,14 +235,14 @@
       "type": "object",
       "defaultValue": {
         "publisher": "Fortinet",
-        "template": "FortiAnalyzer",
-        "provider": "6EB3B02F-50E5-4A3E-8CB8-2E1292583FAZ"
+        "template": "FortiPAM",
+        "provider": "6EB3B02F-50E5-4A3E-8CB8-2E1292583TODO"
       }
     }
   },
   "variables": {
     "imagePublisher": "fortinet",
-    "imageOffer": "fortinet-fortianalyzer",
+    "imageOffer": "fortinet-fortipam",
     "availabilitySetName": "[if(equals(parameters('existingAvailabilitySetName'),''),concat(parameters('namePrefix'),'-availabilityset'),parameters('existingAvailabilitySetName'))]",
     "availabilitySetId": {
       "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
@@ -338,17 +253,11 @@
     "zone1": "[if(equals(parameters('availabilityZoneNumber'),''),pickZones('Microsoft.Compute', 'virtualMachines', parameters('location')),array(parameters('availabilityZoneNumber')))]",
     "vnetName": "[if(equals(parameters('vnetName'),''),concat(parameters('namePrefix'),'-vnet'),parameters('vnetName'))]",
     "subnet1Id": "[if(equals(parameters('vnetNewOrExisting'),'new'),resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), parameters('subnet1Name')),resourceId(parameters('vnetResourceGroup'),'Microsoft.Network/virtualNetworks/subnets', variables('vnetName'),parameters('subnet1Name')))]",
-    "fazVmName": "[concat(parameters('namePrefix'),'-faz-a')]",
-    "customDataHeader": "Content-Type: multipart/mixed; boundary=\"12345\"\nMIME-Version: 1.0\n\n--12345\nContent-Type: text/plain; charset=\"us-ascii\"\nMIME-Version: 1.0\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment; filename=\"config\"\n\n",
-    "customDataBody": "[concat('config system global\n set hostname ',  variables('fazVmName'), '\n end', parameters('additionalCustomData'), variables('customDataFortiFlex'), '\n')]",
-    "customDataLicenseHeader": "--12345\nContent-Type: text/plain; charset=\"us-ascii\"\nMIME-Version: 1.0\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment; filename=\"fgtlicense\"\n\n",
-    "customDataFooter": "\n--12345--\n",
-    "customDataFortiFlex": "[if(equals(parameters('fortiAnalyzerLicenseFortiFlex'),''),'',concat('exec vm-license ',parameters('fortiAnalyzerLicenseFortiFlex'), '\n'))]",
-    "customDataCombined": "[concat(variables('customDataHeader'),variables('customDataBody'),variables('customDataFortiFlex'), variables('customDataLicenseHeader'), parameters('fortiAnalyzerLicenseBYOL'), variables('customDataFooter'))]",
-    "fazCustomData": "[base64(if(equals(parameters('fortiAnalyzerLicenseBYOL'),''),variables('customDataBody'),variables('customDataCombined')))]",
-    "fazNic1Name": "[concat(variables('fazVmName'),'-nic1')]",
-    "fazNic1Id": "[resourceId('Microsoft.Network/networkInterfaces',variables('fazNic1Name'))]",
-    "publicIPName": "[if(equals(parameters('publicIPName'),''),concat(parameters('namePrefix'),'-faz-pip'),parameters('publicIPName'))]",
+    "fpamVmName": "[concat(parameters('namePrefix'),'-fpam-a')]",
+    "fpamCustomData": "[base64(parameters('additionalCustomData'))]",
+    "fpamNic1Name": "[concat(variables('fpamVmName'),'-nic1')]",
+    "fpamNic1Id": "[resourceId('Microsoft.Network/networkInterfaces',variables('fpamNic1Name'))]",
+    "publicIPName": "[if(equals(parameters('publicIPName'),''),concat(parameters('namePrefix'),'-fpam-pip'),parameters('publicIPName'))]",
     "publicIPId": "[if(equals(parameters('publicIPNewOrExisting'),'new'),resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPName')),if(equals(parameters('publicIPNewOrExisting'),'existing'),resourceId(parameters('publicIPResourceGroup'),'Microsoft.Network/publicIPAddresses',variables('publicIPName')),''))]",
     "publicIPAddressId": {
       "id": "[variables('publicIPId')]"
@@ -360,12 +269,12 @@
     "sn1IPArray1": "[string(int(variables('sn1IPArray')[1]))]",
     "sn1IPArray0": "[string(int(variables('sn1IPArray')[0]))]",
     "sn1IPStartAddress": "[split(parameters('subnet1StartAddress'),'.')]",
-    "sn1IPfaz": "[concat(variables('sn1IPArray0'),'.',variables('sn1IPArray1'),'.',variables('sn1IPArray2'),'.',int(variables('sn1IPStartAddress')[3]))]"
+    "sn1IPfpam": "[concat(variables('sn1IPArray0'),'.',variables('sn1IPArray1'),'.',variables('sn1IPArray2'),'.',int(variables('sn1IPStartAddress')[3]))]"
   },
   "resources": [
     {
       "apiVersion": "2022-09-01",
-      "name": "pid-21c3b606-4b14-4eca-ad0d-1d8537ebd14e-partnercenter",
+      "name": "pid-00000000-0000-0000-0000-000000000000-partnercenter",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
@@ -428,7 +337,7 @@
           {
             "name": "AllowSSHInbound",
             "properties": {
-              "description": "Allow SSH In",
+              "description": "Allow SSH (CLI) In",
               "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "22",
@@ -440,23 +349,9 @@
             }
           },
           {
-            "name": "AllowHTTPInbound",
-            "properties": {
-              "description": "Allow 80 In",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "80",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 110,
-              "direction": "Inbound"
-            }
-          },
-          {
             "name": "AllowHTTPSInbound",
             "properties": {
-              "description": "Allow 443 In",
+              "description": "Allow 443 (GUI) In",
               "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "443",
@@ -464,20 +359,6 @@
               "destinationAddressPrefix": "*",
               "access": "Allow",
               "priority": 120,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "AllowDevRegInbound",
-            "properties": {
-              "description": "Allow 514 in for device registration",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "514",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 130,
               "direction": "Inbound"
             }
           },
@@ -524,7 +405,7 @@
         "provider": "[toUpper(parameters('fortinetTags').provider)]"
       },
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "[variables('fazNic1Name')]",
+      "name": "[variables('fpamNic1Name')]",
       "location": "[parameters('location')]",
       "dependsOn": [
         "[variables('vnetName')]",
@@ -535,7 +416,7 @@
           {
             "name": "ipconfig1",
             "properties": {
-              "privateIPAddress": "[variables('sn1IPfaz')]",
+              "privateIPAddress": "[variables('sn1IPfpam')]",
               "privateIPAllocationMethod": "Static",
               "publicIPAddress": "[if(not(equals(parameters('publicIPNewOrExisting'), 'none')), variables('publicIPAddressId') , json('null'))]",
               "subnet": {
@@ -551,7 +432,7 @@
     },
     {
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "[variables('fazVmName')]",
+      "name": "[variables('fpamVmName')]",
       "apiVersion": "2023-03-01",
       "tags": {
         "provider": "[toUpper(parameters('fortinetTags').provider)]"
@@ -567,7 +448,7 @@
         "product": "[variables('imageOffer')]"
       },
       "dependsOn": [
-        "[variables('fazNic1Name')]"
+        "[variables('fpamNic1Name')]"
       ],
       "properties": {
         "hardwareProfile": {
@@ -575,10 +456,10 @@
         },
         "availabilitySet": "[if(variables('useAS'), variables('availabilitySetId'), json('null'))]",
         "osProfile": {
-          "computerName": "[variables('fazVmName')]",
+          "computerName": "[variables('fpamVmName')]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]",
-          "customData": "[variables('fazCustomData')]"
+          "customData": "[variables('fpamCustomData')]"
         },
         "storageProfile": {
           "imageReference": {
@@ -598,7 +479,7 @@
               "name": "dataDisks",
               "count": "[parameters('dataDiskCount')]",
               "input": {
-                "name": "[concat(variables('fazVmName'),'-DataDisk-',copyIndex('dataDisks'))]",
+                "name": "[concat(variables('fpamVmName'),'-DataDisk-',copyIndex('dataDisks'))]",
                 "diskSizeGB": "[parameters('dataDiskSize')]",
                 "lun": "[copyIndex('dataDisks')]",
                 "createOption": "Empty",
@@ -615,7 +496,7 @@
               "properties": {
                 "primary": true
               },
-              "id": "[variables('fazNic1Id')]"
+              "id": "[variables('fpamNic1Id')]"
             }
           ]
         },

--- a/FortiPAM/A-Single-VM/mainTemplate.json
+++ b/FortiPAM/A-Single-VM/mainTemplate.json
@@ -507,5 +507,11 @@
         }
       }
     }
-  ]
+  ],
+  "outputs": {
+    "resourceGroupName": {
+      "type": "string",
+      "value": "[resourceGroup().name]"
+    }
+  }
 }

--- a/FortiPAM/A-Single-VM/mainTemplate.json
+++ b/FortiPAM/A-Single-VM/mainTemplate.json
@@ -1,0 +1,630 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for the Virtual Machine"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the Virtual Machine"
+      }
+    },
+    "namePrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Name for FortiAnalyzer virtual appliances (A & B will be appended to the end of each respectively)"
+      }
+    },
+    "imageSku": {
+      "type": "string",
+      "defaultValue": "fortinet-fortianalyzer",
+      "allowedValues": [
+        "fortinet-fortianalyzer"
+      ],
+      "metadata": {
+        "description": "Identifies the license model"
+      }
+    },
+    "imageVersion": {
+      "type": "string",
+      "defaultValue": "7.4.6",
+      "allowedValues": [
+        "latest",
+        "7.6.6",
+        "7.6.5",
+        "7.6.4",
+        "7.6.3",
+        "7.6.2",
+        "7.6.1",
+        "7.6.0",
+        "7.4.8",
+        "7.4.7",
+        "7.4.6",
+        "7.4.5",
+        "7.4.4",
+        "7.4.3",
+        "7.4.2",
+        "7.4.1",
+        "7.4.0",
+        "7.2.9",
+        "7.2.8",
+        "7.2.7",
+        "7.2.6",
+        "7.2.5",
+        "7.2.4",
+        "7.2.3",
+        "7.2.2",
+        "7.2.11",
+        "7.2.10",
+        "7.2.1",
+        "7.2.0",
+        "7.0.9",
+        "7.0.7",
+        "7.0.6",
+        "7.0.5",
+        "7.0.4",
+        "7.0.3",
+        "7.0.2",
+        "7.0.14",
+        "7.0.13",
+        "7.0.12",
+        "7.0.11",
+        "7.0.10",
+        "7.0.1",
+        "7.0.0",
+        "6.4.9",
+        "6.4.8",
+        "6.4.7",
+        "6.4.6",
+        "6.4.5",
+        "6.4.2",
+        "6.4.15",
+        "6.4.14",
+        "6.4.13",
+        "6.4.12",
+        "6.4.11",
+        "6.4.10",
+        "6.4.1",
+        "6.4.0",
+        "6.2.5",
+        "6.2.3",
+        "6.2.2",
+        "6.2.1",
+        "6.2.0"
+      ],
+      "metadata": {
+        "description": "FortiAnalyzer version"
+      }
+    },
+    "additionalCustomData": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The ARM template provides a basic configuration. Additional configuration can be added here."
+      }
+    },
+    "instanceType": {
+      "type": "string",
+      "defaultValue": "Standard_D4s_v5",
+      "allowedValues": [
+        "Standard_DS4_v2",
+        "Standard_DS5_v2",
+        "Standard_D4_v3",
+        "Standard_D8_v3",
+        "Standard_D16_v3",
+        "Standard_D4a_v4",
+        "Standard_D8a_v4",
+        "Standard_D16a_v4",
+        "Standard_D32a_v4",
+        "Standard_D48a_v4",
+        "Standard_D64a_v4",
+        "Standard_D96a_v4",
+        "Standard_D4as_v4",
+        "Standard_D8as_v4",
+        "Standard_D16as_v4",
+        "Standard_D32as_v4",
+        "Standard_D48as_v4",
+        "Standard_D64as_v4",
+        "Standard_D96as_v4",
+        "Standard_D4_v5",
+        "Standard_D8_v5",
+        "Standard_D16_v5",
+        "Standard_D32_v5",
+        "Standard_D48_v5",
+        "Standard_D64_v5",
+        "Standard_D96_v5",
+        "Standard_D4s_v5",
+        "Standard_D8s_v5",
+        "Standard_D16s_v5",
+        "Standard_D32s_v5",
+        "Standard_D48s_v5",
+        "Standard_D64s_v5",
+        "Standard_D96s_v5"
+      ],
+      "metadata": {
+        "description": "Virtual Machine size selection - must be F4 or other instance that supports 4 NICs"
+      }
+    },
+    "availabilityOptions": {
+      "type": "string",
+      "allowedValues": [
+        "None",
+        "Availability set",
+        "Availability zone"
+      ],
+      "defaultValue": "None",
+      "metadata": {
+        "description": "Deploy FortiAnalyzer VM in an Availability Set or Availability Zones. If Availability Zones deployment is selected but the location does not support Availability Zones an Availability Set will be deployed. If Availability Zones deployment is selected and Availability Zones are available in the location, FortiAnalyzer A will be placed in Zone 1, FortiAnalyzer B will be placed in Zone 2"
+      }
+    },
+    "existingAvailabilitySetName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Name of existing Availability Set in case you want to replace or add a FortiAnalyzer to an existing cluster."
+      }
+    },
+    "availabilityZoneNumber": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Name of existing Availability Set in case you want to replace or add a FortiAnalyzer to an existing cluster."
+      }
+    },
+    "publicIPNewOrExisting": {
+      "type": "string",
+      "defaultValue": "new",
+      "allowedValues": [
+        "new",
+        "existing",
+        "none"
+      ],
+      "metadata": {
+        "description": "Choose between an existing, new or no public IP for the FortiAnalyzer VM"
+      }
+    },
+    "publicIPName": {
+      "type": "string",
+      "defaultValue": "FAZPublicIP",
+      "metadata": {
+        "description": "Name of Public IP address element"
+      }
+    },
+    "publicIPResourceGroup": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Resource group to which the Public IP belongs"
+      }
+    },
+    "vnetNewOrExisting": {
+      "type": "string",
+      "defaultValue": "new",
+      "allowedValues": [
+        "new",
+        "existing"
+      ],
+      "metadata": {
+        "description": "Identify whether to use a new or existing vnet"
+      }
+    },
+    "vnetName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Name of the Azure virtual network"
+      }
+    },
+    "vnetResourceGroup": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Resource Group containing the existing virtual network (with new vnet the current resourcegroup is used)"
+      }
+    },
+    "vnetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "172.16.136.0/22",
+      "metadata": {
+        "description": "Virtual Network Address prefix"
+      }
+    },
+    "subnet1Name": {
+      "type": "string",
+      "defaultValue": "FortiAnalyzerSubnet",
+      "metadata": {
+        "description": "FortiAnalyzer Subnet"
+      }
+    },
+    "subnet1Prefix": {
+      "type": "string",
+      "defaultValue": "172.16.137.0/24",
+      "metadata": {
+        "description": "FortiAnalyzer Subnet Prefix"
+      }
+    },
+    "subnet1StartAddress": {
+      "type": "string",
+      "defaultValue": "172.16.137.4",
+      "metadata": {
+        "description": "Subnet 1 start address, 1 consecutive private IPs are required"
+      }
+    },
+    "serialConsole": {
+      "type": "string",
+      "defaultValue": "yes",
+      "allowedValues": [
+        "yes",
+        "no"
+      ],
+      "metadata": {
+        "description": "Enable Serial Console"
+      }
+    },
+    "diskType": {
+      "type": "string",
+      "defaultValue": "Default",
+      "allowedValues": [
+        "Standard_LRS",
+        "Premium_LRS",
+        "StandardSSD_LRS",
+        "Premium_ZRS",
+        "StandardSSD_ZRS",
+        "Default"
+      ],
+      "metadata": {
+        "description": "Type of all of the disks, this determines the IOPS and redudancy"
+      }
+    },
+    "dataDiskSize": {
+      "type": "string",
+      "defaultValue": "1024",
+      "metadata": {
+        "description": "Size of the logfile data disk"
+      }
+    },
+    "dataDiskCount": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "Number of data disk"
+      }
+    },
+    "fortiAnalyzerLicenseBYOL": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "FortiAnalyzer BYOL license content"
+      }
+    },
+    "fortiAnalyzerLicenseFortiFlex": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "FortiAnalyzer BYOL FortiFlex license token"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    },
+    "fortinetTags": {
+      "type": "object",
+      "defaultValue": {
+        "publisher": "Fortinet",
+        "template": "FortiAnalyzer",
+        "provider": "6EB3B02F-50E5-4A3E-8CB8-2E1292583FAZ"
+      }
+    }
+  },
+  "variables": {
+    "imagePublisher": "fortinet",
+    "imageOffer": "fortinet-fortianalyzer",
+    "availabilitySetName": "[if(equals(parameters('existingAvailabilitySetName'),''),concat(parameters('namePrefix'),'-availabilityset'),parameters('existingAvailabilitySetName'))]",
+    "availabilitySetId": {
+      "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
+    },
+    "useAS": "[equals(parameters('availabilityOptions'), 'Availability set')]",
+    "useAZ": "[and(not(empty(pickZones('Microsoft.Compute', 'virtualMachines', parameters('location')))), equals(parameters('availabilityOptions'), 'Availability zone'))]",
+    "pipZones": "[if(variables('useAZ'), pickZones('Microsoft.Network', 'publicIPAddresses', parameters('location'), 3), json('null'))]",
+    "zone1": "[if(equals(parameters('availabilityZoneNumber'),''),pickZones('Microsoft.Compute', 'virtualMachines', parameters('location')),array(parameters('availabilityZoneNumber')))]",
+    "vnetName": "[if(equals(parameters('vnetName'),''),concat(parameters('namePrefix'),'-vnet'),parameters('vnetName'))]",
+    "subnet1Id": "[if(equals(parameters('vnetNewOrExisting'),'new'),resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), parameters('subnet1Name')),resourceId(parameters('vnetResourceGroup'),'Microsoft.Network/virtualNetworks/subnets', variables('vnetName'),parameters('subnet1Name')))]",
+    "fazVmName": "[concat(parameters('namePrefix'),'-faz-a')]",
+    "customDataHeader": "Content-Type: multipart/mixed; boundary=\"12345\"\nMIME-Version: 1.0\n\n--12345\nContent-Type: text/plain; charset=\"us-ascii\"\nMIME-Version: 1.0\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment; filename=\"config\"\n\n",
+    "customDataBody": "[concat('config system global\n set hostname ',  variables('fazVmName'), '\n end', parameters('additionalCustomData'), variables('customDataFortiFlex'), '\n')]",
+    "customDataLicenseHeader": "--12345\nContent-Type: text/plain; charset=\"us-ascii\"\nMIME-Version: 1.0\nContent-Transfer-Encoding: 7bit\nContent-Disposition: attachment; filename=\"fgtlicense\"\n\n",
+    "customDataFooter": "\n--12345--\n",
+    "customDataFortiFlex": "[if(equals(parameters('fortiAnalyzerLicenseFortiFlex'),''),'',concat('exec vm-license ',parameters('fortiAnalyzerLicenseFortiFlex'), '\n'))]",
+    "customDataCombined": "[concat(variables('customDataHeader'),variables('customDataBody'),variables('customDataFortiFlex'), variables('customDataLicenseHeader'), parameters('fortiAnalyzerLicenseBYOL'), variables('customDataFooter'))]",
+    "fazCustomData": "[base64(if(equals(parameters('fortiAnalyzerLicenseBYOL'),''),variables('customDataBody'),variables('customDataCombined')))]",
+    "fazNic1Name": "[concat(variables('fazVmName'),'-nic1')]",
+    "fazNic1Id": "[resourceId('Microsoft.Network/networkInterfaces',variables('fazNic1Name'))]",
+    "publicIPName": "[if(equals(parameters('publicIPName'),''),concat(parameters('namePrefix'),'-faz-pip'),parameters('publicIPName'))]",
+    "publicIPId": "[if(equals(parameters('publicIPNewOrExisting'),'new'),resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPName')),if(equals(parameters('publicIPNewOrExisting'),'existing'),resourceId(parameters('publicIPResourceGroup'),'Microsoft.Network/publicIPAddresses',variables('publicIPName')),''))]",
+    "publicIPAddressId": {
+      "id": "[variables('publicIPId')]"
+    },
+    "serialConsoleEnabled": "[if(equals(parameters('serialConsole'),'yes'),'true','false')]",
+    "NSGName": "[concat(parameters('namePrefix'),'-',uniqueString(resourceGroup().id),'-nsg')]",
+    "sn1IPArray": "[split(parameters('subnet1Prefix'),'.')]",
+    "sn1IPArray2": "[string(int(variables('sn1IPArray')[2]))]",
+    "sn1IPArray1": "[string(int(variables('sn1IPArray')[1]))]",
+    "sn1IPArray0": "[string(int(variables('sn1IPArray')[0]))]",
+    "sn1IPStartAddress": "[split(parameters('subnet1StartAddress'),'.')]",
+    "sn1IPfaz": "[concat(variables('sn1IPArray0'),'.',variables('sn1IPArray1'),'.',variables('sn1IPArray2'),'.',int(variables('sn1IPStartAddress')[3]))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2022-09-01",
+      "name": "pid-21c3b606-4b14-4eca-ad0d-1d8537ebd14e-partnercenter",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": []
+        }
+      }
+    },
+    {
+      "condition": "[and(variables('useAS'),equals(parameters('existingAvailabilitySetName'),''))]",
+      "type": "Microsoft.Compute/availabilitySets",
+      "apiVersion": "2023-03-01",
+      "name": "[variables('availabilitySetName')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "provider": "[toUpper(parameters('fortinetTags').provider)]"
+      },
+      "properties": {
+        "platformFaultDomainCount": 2,
+        "platformUpdateDomainCount": 2
+      },
+      "sku": {
+        "name": "Aligned"
+      }
+    },
+    {
+      "condition": "[equals(parameters('vnetNewOrExisting'), 'new')]",
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2023-04-01",
+      "name": "[variables('vnetName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('vnetAddressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[parameters('subnet1Name')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnet1Prefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2023-04-01",
+      "tags": {
+        "provider": "[toUpper(parameters('fortinetTags').provider)]"
+      },
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('NSGName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "AllowSSHInbound",
+            "properties": {
+              "description": "Allow SSH In",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "AllowHTTPInbound",
+            "properties": {
+              "description": "Allow 80 In",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "80",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 110,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "AllowHTTPSInbound",
+            "properties": {
+              "description": "Allow 443 In",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "443",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 120,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "AllowDevRegInbound",
+            "properties": {
+              "description": "Allow 514 in for device registration",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "514",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 130,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "AllowAllOutbound",
+            "properties": {
+              "description": "Allow all out",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 105,
+              "direction": "Outbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "condition": "[equals(parameters('publicIPNewOrExisting'), 'new')]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPName')]",
+      "apiVersion": "2023-04-01",
+      "location": "[parameters('location')]",
+      "tags": {
+        "provider": "[toUpper(parameters('fortinetTags').provider)]"
+      },
+      "sku": {
+        "name": "Standard"
+      },
+      "zones": "[variables('pipZones')]",
+      "properties": {
+        "publicIPAllocationMethod": "Static",
+        "dnsSettings": {
+          "domainNameLabel": "[concat(toLower(variables('publicIPName')), '-', uniquestring(resourceGroup().id))]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2023-04-01",
+      "tags": {
+        "provider": "[toUpper(parameters('fortinetTags').provider)]"
+      },
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('fazNic1Name')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[variables('vnetName')]",
+        "[variables('NSGName')]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAddress": "[variables('sn1IPfaz')]",
+              "privateIPAllocationMethod": "Static",
+              "publicIPAddress": "[if(not(equals(parameters('publicIPNewOrExisting'), 'none')), variables('publicIPAddressId') , json('null'))]",
+              "subnet": {
+                "id": "[variables('subnet1Id')]"
+              }
+            }
+          }
+        ],
+        "networkSecurityGroup": {
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups/',variables('NSGName'))]"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[variables('fazVmName')]",
+      "apiVersion": "2023-03-01",
+      "tags": {
+        "provider": "[toUpper(parameters('fortinetTags').provider)]"
+      },
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "zones": "[if(variables('useAZ'), variables('zone1'), json('null'))]",
+      "plan": {
+        "name": "[parameters('imageSku')]",
+        "publisher": "[variables('imagePublisher')]",
+        "product": "[variables('imageOffer')]"
+      },
+      "dependsOn": [
+        "[variables('fazNic1Name')]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('instanceType')]"
+        },
+        "availabilitySet": "[if(variables('useAS'), variables('availabilitySetId'), json('null'))]",
+        "osProfile": {
+          "computerName": "[variables('fazVmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]",
+          "customData": "[variables('fazCustomData')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[parameters('imageSku')]",
+            "version": "[parameters('imageVersion')]"
+          },
+          "osDisk": {
+            "createOption": "FromImage",
+            "managedDisk": {
+              "storageAccountType": "[if(not(equals(parameters('diskType'), 'Default')), parameters('diskType') , json('null'))]"
+            }
+          },
+          "copy": [
+            {
+              "name": "dataDisks",
+              "count": "[parameters('dataDiskCount')]",
+              "input": {
+                "name": "[concat(variables('fazVmName'),'-DataDisk-',copyIndex('dataDisks'))]",
+                "diskSizeGB": "[parameters('dataDiskSize')]",
+                "lun": "[copyIndex('dataDisks')]",
+                "createOption": "Empty",
+                "managedDisk": {
+                  "storageAccountType": "[if(not(equals(parameters('diskType'), 'Default')), parameters('diskType') , json('null'))]"
+                }
+              }
+            }
+          ]
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "properties": {
+                "primary": true
+              },
+              "id": "[variables('fazNic1Id')]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": "[variables('serialConsoleEnabled')]"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/FortiPAM/A-Single-VM/mainTemplate.parameters.json
+++ b/FortiPAM/A-Single-VM/mainTemplate.parameters.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "adminUsername": {
+            "value": "## TO BE DEFINED ##"
+        },
+        "adminPassword": {
+            "value": "## TO BE DEFINED ##"
+        },
+        "namePrefix": {
+            "value": "## TO BE DEFINED ##"
+        },
+        "imageSku": {
+            "value": "fortinet-fortianalyzer"
+        },
+        "imageVersion": {
+            "value": "latest"
+        },
+        "instanceType": {
+            "value": "Standard_D2s_v3"
+        },
+        "publicIPNewOrExisting": {
+            "value": "new"
+        },
+        "publicIPName": {
+            "value": "FAZPublicIP"
+        },
+        "publicIPResourceGroup": {
+            "value": ""
+        },
+        "publicIPAddressType": {
+            "value": "Static"
+        },
+        "vnetNewOrExisting": {
+            "value": "new"
+        },
+        "vnetName": {
+            "value": ""
+        },
+        "vnetResourceGroup": {
+            "value": ""
+        },
+        "vnetAddressPrefix": {
+            "value": "172.16.136.0/22"
+        },
+        "subnet1Name": {
+            "value": "FortiAnalyzerSubnet"
+        },
+        "subnet1Prefix": {
+            "value": "172.16.137.0/24"
+        },
+        "dataDiskSize": {
+            "value": "1024"
+        },
+        "location": {
+            "value": "[resourceGroup().location]"
+        },
+        "fortinetTags": {
+            "value": {
+                "publisher": "Fortinet",
+                "template": "FortiAnalyzer",
+                "provider": "6EB3B02F-50E5-4A3E-8CB8-2E1292583FAZ"
+            }
+        }
+    }
+}

--- a/FortiPAM/A-Single-VM/mainTemplate.parameters.json
+++ b/FortiPAM/A-Single-VM/mainTemplate.parameters.json
@@ -12,25 +12,28 @@
             "value": "## TO BE DEFINED ##"
         },
         "imageSku": {
-            "value": "fortinet-fortianalyzer"
+            "value": "fortinet-fpam"
         },
         "imageVersion": {
             "value": "latest"
         },
         "instanceType": {
-            "value": "Standard_D2s_v3"
+            "value": "Standard_D4s_v5"
+        },
+        "dataDiskSize": {
+            "value": "128"
+        },
+        "dataDiskCount": {
+            "value": 2
         },
         "publicIPNewOrExisting": {
             "value": "new"
         },
         "publicIPName": {
-            "value": "FAZPublicIP"
+            "value": "FPAMPublicIP"
         },
         "publicIPResourceGroup": {
             "value": ""
-        },
-        "publicIPAddressType": {
-            "value": "Static"
         },
         "vnetNewOrExisting": {
             "value": "new"
@@ -45,13 +48,10 @@
             "value": "172.16.136.0/22"
         },
         "subnet1Name": {
-            "value": "FortiAnalyzerSubnet"
+            "value": "FortiPAMSubnet"
         },
         "subnet1Prefix": {
             "value": "172.16.137.0/24"
-        },
-        "dataDiskSize": {
-            "value": "1024"
         },
         "location": {
             "value": "[resourceGroup().location]"
@@ -59,8 +59,8 @@
         "fortinetTags": {
             "value": {
                 "publisher": "Fortinet",
-                "template": "FortiAnalyzer",
-                "provider": "6EB3B02F-50E5-4A3E-8CB8-2E1292583FAZ"
+                "template": "FortiPAM",
+                "provider": "6EB3B02F-50E5-4A3E-8CB8-2E1292583TODO"
             }
         }
     }

--- a/FortiPAM/A-Single-VM/test/azuredeploy.tests.ps1
+++ b/FortiPAM/A-Single-VM/test/azuredeploy.tests.ps1
@@ -1,0 +1,180 @@
+#Requires -Modules Pester
+<#
+.SYNOPSIS
+    Tests a specific ARM template
+.EXAMPLE
+    Invoke-Pester
+.NOTES
+    This file has been created as an example of using Pester to evaluate ARM templates
+#>
+
+param (
+  [string]$sshkey,
+  [string]$sshkeypub
+)
+$VerbosePreference = "Continue"
+
+BeforeAll {
+  $templateName = "A-Single-VM"
+  $sourcePath = "$env:GITHUB_WORKSPACE\FortiWeb\$templateName"
+  $scriptPath = "$env:GITHUB_WORKSPACE\FortiWeb\$templateName\test"
+  $templateFileName = "mainTemplate.json"
+  $templateFileLocation = "$sourcePath\$templateFileName"
+  $templateParameterFileName = "mainTemplate.parameters.json"
+  $templateParameterFileLocation = "$sourcePath\$templateParameterFileName"
+
+  # Basic Variables
+  $testsRandom = Get-Random 10001
+  $testsPrefix = "FORTIQA"
+  $testsResourceGroupName = "FORTIQA-$testsRandom-$templateName"
+  $testsAdminUsername = "azureuser"
+  $testsResourceGroupLocation = "westeurope"
+
+  # ARM Template Variables
+  $config = "config system console `n set output standard `n end `n config system admin `n edit devops `n set access-profil prof_admin `n set sshkey `""
+  $config += Get-Content $sshkeypub
+  $config += "`" `n set password $testsResourceGroupName `n next `n end"
+  $publicIPName = "$testsPrefix-fwb-pip"
+  $params = @{ 'adminUsername'     = $testsAdminUsername
+    'adminPassword'                = $testsResourceGroupName
+    'fortiWebNamePrefix'           = $testsPrefix
+    'fortiWebAdditionalCustomData' = $config
+    'publicIPName'                 = $publicIPName
+  }
+  $ports = @(8443, 22)
+}
+
+Describe 'FWB Single VM' {
+  Context 'Validation' {
+    It 'Has a JSON template' {
+      $templateFileLocation | Should -Exist
+    }
+
+    It 'Has a parameters file' {
+      $templateParameterFileLocation | Should -Exist
+    }
+
+    It 'Converts from JSON and has the expected properties' {
+      $expectedProperties = '$schema',
+      'contentVersion',
+      'outputs',
+      'parameters',
+      'resources',
+      'variables'
+      $templateProperties = (get-content $templateFileLocation | ConvertFrom-Json -ErrorAction SilentlyContinue) | Get-Member -MemberType NoteProperty | % Name
+      $diff = ( Compare-Object -ReferenceObject $expectedProperties -DifferenceObject $templateProperties | Format-Table | Out-String )
+      if ($diff) { Write-Host ( "Diff: $diff" ) }
+      $templateProperties | Should -Be $expectedProperties
+    }
+
+    It 'Creates the expected Azure resources' {
+      $expectedResources = 'Microsoft.Resources/deployments',
+      'Microsoft.Network/virtualNetworks',
+      'Microsoft.Network/networkSecurityGroups',
+      'Microsoft.Network/publicIPAddresses',
+      'Microsoft.Network/networkInterfaces',
+      'Microsoft.Network/networkInterfaces',
+      'Microsoft.Compute/virtualMachines'
+      $templateResources = (get-content $templateFileLocation | ConvertFrom-Json -ErrorAction SilentlyContinue).Resources.type
+      $diff = ( Compare-Object -ReferenceObject $expectedResources -DifferenceObject $templateResources | Format-Table | Out-String )
+      if ($diff) { Write-Host ( "Diff: $diff" ) }
+      $templateResources | Should -Be $expectedResources
+    }
+
+    It 'Contains the expected parameters' {
+      $expectedTemplateParameters = 'acceleratedNetworking',
+      'adminPassword',
+      'adminUsername',
+      'availabilityOptions',
+      'availabilityZoneNumber',
+      'existingAvailabilitySetName',
+      'fortinetTags',
+      'fortiWebAdditionalCustomData',
+      'fortiWebLicenseBYOL',
+      'fortiWebLicenseFortiFlex',
+      'fortiWebNamePrefix',
+      'imageSku',
+      'imageVersion',
+      'instanceType',
+      'location',
+      'publicIPName',
+      'publicIPNewOrExistingOrNone',
+      'publicIPResourceGroup',
+      'publicIPSku',
+      'publicIPType',
+      'serialConsole',
+      'subnet1Name',
+      'subnet1Prefix',
+      'subnet1StartAddress',
+      'subnet2Name',
+      'subnet2Prefix',
+      'subnet2StartAddress',
+      'tagsByResource',
+      'vnetAddressPrefix',
+      'vnetName',
+      'vnetNewOrExisting',
+      'vnetResourceGroup'
+      $templateParameters = (get-content $templateFileLocation | ConvertFrom-Json -ErrorAction SilentlyContinue).Parameters | Get-Member -MemberType NoteProperty | % Name | Sort-Object
+      $diff = ( Compare-Object -ReferenceObject $expectedTemplateParameters -DifferenceObject $templateParameters | Format-Table | Out-String )
+      if ($diff) { Write-Host ( "Diff: $diff" ) }
+      $templateParameters | Should -Be $expectedTemplateParameters
+    }
+
+  }
+
+  Context 'Deployment' {
+
+    It "Test Deployment" {
+      New-AzResourceGroup -Name $testsResourceGroupName -Location "$testsResourceGroupLocation"
+            (Test-AzResourceGroupDeployment -ResourceGroupName "$testsResourceGroupName" -TemplateFile "$templateFileLocation" -TemplateParameterObject $params).Count | Should -Not -BeGreaterThan 0
+    }
+    It "Deployment" {
+      Write-Host ( "Deployment name: $testsResourceGroupName" )
+
+      $resultDeployment = New-AzResourceGroupDeployment -ResourceGroupName "$testsResourceGroupName" -TemplateFile "$templateFileLocation" -TemplateParameterObject $params
+      Write-Host ($resultDeployment | Format-Table | Out-String)
+      Write-Host ("Deployment state: " + $resultDeployment.ProvisioningState | Out-String)
+      $resultDeployment.ProvisioningState | Should -Be "Succeeded"
+    }
+    It "Search deployment" {
+      $result = Get-AzVM | Where-Object { $_.Name -like "$testsPrefix*" }
+      Write-Host ($result | Format-Table | Out-String)
+      $result | Should -Not -Be $null
+    }
+  }
+
+  Context 'Deployment test' {
+
+    BeforeAll {
+      $fwb = (Get-AzPublicIpAddress -Name $publicIPName -ResourceGroupName $testsResourceGroupName).IpAddress
+      Write-Host ("FortiWeb public IP: " + $fwb)
+      $verify_commands = @'
+        get system status
+        show system interface
+        diag debug cloudinit show
+        exit
+'@
+      $OFS = "`n"
+    }
+    It "FWB: Ports listening" {
+      ForEach ( $port in $ports ) {
+        Write-Host ("Check port: $port" )
+        $portListening = (Test-Connection -TargetName $fwb -TCPPort $port -TimeoutSeconds 100)
+        $portListening | Should -Be $true
+      }
+    }
+    It "FWB: Verify FortiWeb configuration" {
+      $result = $($verify_commands | ssh -tt -i $sshkey -o StrictHostKeyChecking=no devops@$fwb)
+      $LASTEXITCODE | Should -Be "0"
+      Write-Host ("FWB CLI info: " + $result) -Separator `n
+      $result | Should -Not -BeLike "*Command fail*"
+      $result | Should -Not -BeLike "*Timeout*"
+    }
+  }
+
+  Context 'Cleanup' {
+    It "Cleanup of deployment" {
+      Remove-AzResourceGroup -Name $testsResourceGroupName -Force
+    }
+  }
+}

--- a/FortiPAM/A-Single-VM/test/azuredeploy.tests.ps1
+++ b/FortiPAM/A-Single-VM/test/azuredeploy.tests.ps1
@@ -66,6 +66,7 @@ Describe 'FPAM Single VM' {
     It 'Creates the expected Azure resources' {
       # FPAM = single NIC (one networkInterfaces entry), unlike the dual-NIC variant.
       $expectedResources = 'Microsoft.Resources/deployments',
+      'Microsoft.Compute/availabilitySets',
       'Microsoft.Network/virtualNetworks',
       'Microsoft.Network/networkSecurityGroups',
       'Microsoft.Network/publicIPAddresses',

--- a/FortiPAM/A-Single-VM/test/azuredeploy.tests.ps1
+++ b/FortiPAM/A-Single-VM/test/azuredeploy.tests.ps1
@@ -1,23 +1,18 @@
 #Requires -Modules Pester
 <#
 .SYNOPSIS
-    Tests a specific ARM template
+    Tests the FortiPAM A-Single-VM ARM template
 .EXAMPLE
     Invoke-Pester
 .NOTES
-    This file has been created as an example of using Pester to evaluate ARM templates
+    Docs-faithful: no customData config injection, no SSH-key injection.
+    Verifies TTK-style structure + deploy + ports 22/443 + HTTPS reachable.
 #>
-
-param (
-  [string]$sshkey,
-  [string]$sshkeypub
-)
-$VerbosePreference = "Continue"
 
 BeforeAll {
   $templateName = "A-Single-VM"
-  $sourcePath = "$env:GITHUB_WORKSPACE\FortiWeb\$templateName"
-  $scriptPath = "$env:GITHUB_WORKSPACE\FortiWeb\$templateName\test"
+  $sourcePath = "$env:GITHUB_WORKSPACE\FortiPAM\$templateName"
+  $scriptPath = "$env:GITHUB_WORKSPACE\FortiPAM\$templateName\test"
   $templateFileName = "mainTemplate.json"
   $templateFileLocation = "$sourcePath\$templateFileName"
   $templateParameterFileName = "mainTemplate.parameters.json"
@@ -30,21 +25,22 @@ BeforeAll {
   $testsAdminUsername = "azureuser"
   $testsResourceGroupLocation = "westeurope"
 
-  # ARM Template Variables
-  $config = "config system console `n set output standard `n end `n config system admin `n edit devops `n set access-profil prof_admin `n set sshkey `""
-  $config += Get-Content $sshkeypub
-  $config += "`" `n set password $testsResourceGroupName `n next `n end"
-  $publicIPName = "$testsPrefix-fwb-pip"
-  $params = @{ 'adminUsername'     = $testsAdminUsername
-    'adminPassword'                = $testsResourceGroupName
-    'fortiWebNamePrefix'           = $testsPrefix
-    'fortiWebAdditionalCustomData' = $config
-    'publicIPName'                 = $publicIPName
+  # ARM Template Variables -- docs-faithful: no customData, no license injection.
+  $publicIPName = "$testsPrefix-fpam-pip"
+  $params = @{
+    'adminUsername'      = $testsAdminUsername
+    'adminPassword'      = $testsResourceGroupName
+    'namePrefix'         = $testsPrefix
+    'imageSku'           = 'fortinet-fpam'
+    'imageVersion'       = '1.9.0'
+    'instanceType'       = 'Standard_D4s_v5'
+    'publicIPName'       = $publicIPName
+    'dataDiskCount'      = 2
   }
-  $ports = @(8443, 22)
+  $ports = @(22, 443)
 }
 
-Describe 'FWB Single VM' {
+Describe 'FPAM Single VM' {
   Context 'Validation' {
     It 'Has a JSON template' {
       $templateFileLocation | Should -Exist
@@ -68,11 +64,11 @@ Describe 'FWB Single VM' {
     }
 
     It 'Creates the expected Azure resources' {
+      # FPAM = single NIC (one networkInterfaces entry), unlike the dual-NIC variant.
       $expectedResources = 'Microsoft.Resources/deployments',
       'Microsoft.Network/virtualNetworks',
       'Microsoft.Network/networkSecurityGroups',
       'Microsoft.Network/publicIPAddresses',
-      'Microsoft.Network/networkInterfaces',
       'Microsoft.Network/networkInterfaces',
       'Microsoft.Compute/virtualMachines'
       $templateResources = (get-content $templateFileLocation | ConvertFrom-Json -ErrorAction SilentlyContinue).Resources.type
@@ -82,34 +78,28 @@ Describe 'FWB Single VM' {
     }
 
     It 'Contains the expected parameters' {
-      $expectedTemplateParameters = 'acceleratedNetworking',
+      $expectedTemplateParameters = 'additionalCustomData',
       'adminPassword',
       'adminUsername',
       'availabilityOptions',
       'availabilityZoneNumber',
+      'dataDiskCount',
+      'dataDiskSize',
+      'diskType',
       'existingAvailabilitySetName',
       'fortinetTags',
-      'fortiWebAdditionalCustomData',
-      'fortiWebLicenseBYOL',
-      'fortiWebLicenseFortiFlex',
-      'fortiWebNamePrefix',
       'imageSku',
       'imageVersion',
       'instanceType',
       'location',
+      'namePrefix',
       'publicIPName',
-      'publicIPNewOrExistingOrNone',
+      'publicIPNewOrExisting',
       'publicIPResourceGroup',
-      'publicIPSku',
-      'publicIPType',
       'serialConsole',
       'subnet1Name',
       'subnet1Prefix',
       'subnet1StartAddress',
-      'subnet2Name',
-      'subnet2Prefix',
-      'subnet2StartAddress',
-      'tagsByResource',
       'vnetAddressPrefix',
       'vnetName',
       'vnetNewOrExisting',
@@ -146,29 +136,30 @@ Describe 'FWB Single VM' {
   Context 'Deployment test' {
 
     BeforeAll {
-      $fwb = (Get-AzPublicIpAddress -Name $publicIPName -ResourceGroupName $testsResourceGroupName).IpAddress
-      Write-Host ("FortiWeb public IP: " + $fwb)
-      $verify_commands = @'
-        get system status
-        show system interface
-        diag debug cloudinit show
-        exit
-'@
-      $OFS = "`n"
+      $fpam = (Get-AzPublicIpAddress -Name $publicIPName -ResourceGroupName $testsResourceGroupName).IpAddress
+      Write-Host ("FortiPAM public IP: " + $fpam)
     }
-    It "FWB: Ports listening" {
+
+    It "FPAM: Ports listening" {
       ForEach ( $port in $ports ) {
         Write-Host ("Check port: $port" )
-        $portListening = (Test-Connection -TargetName $fwb -TCPPort $port -TimeoutSeconds 100)
+        $portListening = (Test-Connection -TargetName $fpam -TCPPort $port -TimeoutSeconds 100)
         $portListening | Should -Be $true
       }
     }
-    It "FWB: Verify FortiWeb configuration" {
-      $result = $($verify_commands | ssh -tt -i $sshkey -o StrictHostKeyChecking=no devops@$fwb)
-      $LASTEXITCODE | Should -Be "0"
-      Write-Host ("FWB CLI info: " + $result) -Separator `n
-      $result | Should -Not -BeLike "*Command fail*"
-      $result | Should -Not -BeLike "*Timeout*"
+
+    It "FPAM: HTTPS GUI reachable" {
+      # Docs-faithful: FortiPAM license is uploaded post-deploy via SCP, so the
+      # GUI may show a license-upload page rather than a login screen. We assert
+      # only that HTTPS (443) returns an HTTP response, not a specific page body.
+      $resp = $null
+      try {
+        $resp = Invoke-WebRequest -Uri "https://$fpam/" -SkipCertificateCheck -TimeoutSec 100 -UseBasicParsing
+      } catch {
+        $resp = $_.Exception.Response
+      }
+      Write-Host ("HTTPS status: " + $resp.StatusCode)
+      $resp | Should -Not -Be $null
     }
   }
 


### PR DESCRIPTION
# Add FortiPAM A-Single-VM building block

## Summary

Adds the `FortiPAM/A-Single-VM/` building block (7 files) plus the `.github/workflows/fpam-arm-a-single-vm.yml` CI workflow to the `40net-cloud/fortinet-azure-solutions` repo -- all greenfield (no existing files modified), 9 commits, 1772 insertions. The ARM template deploys a single FortiPAM VM from the marketplace image `fortinet:fortinet-fortipam:fortinet-fpam:1.9.0`, docs-faithful (no `customData` config injection, no SSH-key injection -- license is uploaded post-deploy via SCP), with 2 data disks and an NSG exposing only ports 22 and 443. The CI workflow mirrors the FortiWeb pattern: an ARM-TTK validation job (no Azure secrets) gating an OIDC deploy+Pester job, x64-only (no matrix), with a Teams notification job.

Branch: `feature/fortipam-a-single-vm`. Built via subagent-driven development with per-task reviews + a final whole-branch review.

## Placeholder Registry (attribution GUIDs -- non-blocking, attribution-only)

Two intentional, clearly-marked GUID placeholders remain. They do NOT block deployment or validation (`az deployment group validate` succeeds with them in place). Whoever supplies the real values:

### 1. `fortinetTags.provider` attribution tag (Fortinet-internal)
Replace `6EB3B02F-50E5-4A3E-8CB8-2E1292583TODO` with the real FortiPAM provider suffix (convention: shared base `6EB3B02F-50E5-4A3E-8CB8-2E1292583` + per-product suffix; e.g. FAZ uses `...3FAZ`).
- `FortiPAM/A-Single-VM/mainTemplate.json` line 239 -- `fortinetTags.defaultValue.provider`
- `FortiPAM/A-Single-VM/mainTemplate.parameters.json` line 63 -- `fortinetTags.value.provider`

**Ask:** the repo maintainer for the FortiPAM suffix. Both occurrences must be updated to the same value.

### 2. Partner Center PID (CUA) GUID
- `FortiPAM/A-Single-VM/mainTemplate.json` line 277 -- resource `name`: `pid-00000000-0000-0000-0000-000000000000-partnercenter`

**Ask:** Partner Center for the Customer Usage Attribution (CUA) GUID; replace the `00000000-0000-0000-0000-000000000000` segment in the resource name (enter the GUID without the `pid-` prefix when registering it under Partner Center -> Settings -> Account settings -> Organization profile -> Identifiers -> Add Tracking GUID).

Both placeholders are also documented in `FortiPAM/A-Single-VM/README.md` (TODO section). Both are attribution-only -- neither is validated at deploy time.

## Verification Outcome

### Local validation (all PASS)
- `jq .` on `mainTemplate.json`, `createUiDefinition.json`, `mainTemplate.parameters.json` -- all exit 0, valid JSON.
- `bash -n deploy.sh` -- syntax OK. `python3 yaml.safe_load` on the workflow -- valid YAML.
- Cross-file consistency (programmatically verified): all 25 `createUiDefinition.outputs` bind to params that exist in `mainTemplate.json`; the one template param not surfaced by the UI (`fortinetTags`) has a default; all 19 params-file keys are a subset of the template params; all required (no-default) template params are covered.
- Pester `expectedTemplateParameters` (26) matches the template's 26 `parameters` keys exactly (sorted compare, no diff). `expectedResources` (7) matches the template's 7 declared resource types exactly, in declaration order. `expectedProperties` (6) matches the template's top-level keys exactly.
- `az deployment group validate` against the final template -- **`provisioningState: Succeeded`, `error: null`, exit 0.** Marketplace terms accepted on Canada-PAYG. Temp RG deleted. **The template is deploy-ready.**

### CI run -- deferred (access wall)
The author has **pull-only** access to `40net-cloud/fortinet-azure-solutions` (`push:false`, `admin:false`), so the branch could not be pushed and the workflow could not be triggered from the build environment. To verify CI:
1. Get the branch into the repo (grant push to a feature branch, or fork + open a PR).
2. Merge to `main` before relying on the deploy job -- the repo's OIDC federated credential is proven for `refs/heads/main` only (verified: FGT A-Single-VM run 26821568521 on main, Azure Login step succeeded). A feature-branch deploy run may fail `Azure Login` with an `AADSTS70021`/federated-credential error; that is expected, not an app defect -- merge to `main` and re-run.
3. Accept marketplace terms in the CI subscription if not already: `az vm image terms accept --urn fortinet:fortinet-fortipam:fortinet-fpam:1.9.0` (terms are per-subscription; accepted on Canada-PAYG for the local validate, but the CI subscription may differ).
4. Run the workflow (`gh workflow run fpam-arm-a-single-vm.yml` or Actions tab `workflow_dispatch`), then `gh run watch --exit-status`.

## Residual CI risks to watch (observational, not blocking)

- **FortiPAM boot time vs port-check timeout.** The Pester port check uses `Test-Connection -TimeoutSeconds 100` (100s/port) and the HTTPS check `Invoke-WebRequest -TimeoutSec 100`. FortiPAM may take longer than 100s on first boot. If `Test-Connection` times out on 22/443, raise `TimeoutSeconds` and/or add a `Start-Sleep` before the port check in `test/azuredeploy.tests.ps1`.
- **HTTPS GUI on first boot.** The HTTPS `It` asserts only that port 443 returns an HTTP response (not a specific page), because the GUI may show a license-upload page rather than a login screen on first boot. If `Invoke-WebRequest` returns null within 100s, add a retry loop or longer timeout.
- **arm-ttk PID resource.** The nested PID `Microsoft.Resources/deployments` resource uses the standard CUA-tracking pattern (inner template with `resources: []`, inherited verbatim from FAZ). `az validate` succeeded with it. If arm-ttk recurses into it and flags the all-zero placeholder PID, swap in the real CUA GUID (Placeholder Registry #2) rather than reverting to FAZ's GUID.

## Note on the committed `mainTemplate.parameters.json` `location` value
The params file sets `"location": { "value": "[resourceGroup().location]" }` (identical to the FAZ reference). `az deployment group validate` with this value passed through returns `InvalidResourceLocation` (the expression is not evaluated by `validate` when supplied as a parameter value). This is a `validate`-only quirk: omitting `location` (using the template default, which IS evaluated in template context) validates successfully, and the CI Pester deploy uses inline params that omit `location`. No change needed; flagged for transparency.
